### PR TITLE
Update Docker commands in documentation

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -5,7 +5,7 @@ Modern, web-based steel fabrication management system replacing legacy FabTrol.
 ## Commands
 
 ### Backend (Laravel)
-- **Start Env**: `docker-compose up -d`
+- **Start Env**: `docker compose up -d`
 - **Migrations**: `php artisan migrate`
 - **Seed Data**: `php artisan db:seed`
 - **Import Legacy**: `php artisan migrate:fabtrol all`

--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ git clone https://github.com/meistro57/SteelFlow-MRP.git && cd SteelFlow-MRP
 cp .env.example .env
 
 # 3. Launch the containers
-docker-compose up -d
+docker compose up -d
 
 # 4. Initialize the application
-docker-compose exec app composer install
-docker-compose exec app php artisan key:generate
-docker-compose exec app php artisan migrate --seed
+docker compose exec app composer install
+docker compose exec app php artisan key:generate
+docker compose exec app php artisan migrate --seed
 
 # 5. Compile the frontend
 npm install && npm run dev

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -29,11 +29,11 @@ Once installed, verify the integrity of the system by running the full test suit
 
 ```bash
 # Run all tests
-docker-compose exec app php artisan test
+docker compose exec app php artisan test
 
 # Run specific suites
-docker-compose exec app php artisan test --testsuite=Unit
-docker-compose exec app php artisan test --testsuite=Feature
+docker compose exec app php artisan test --testsuite=Unit
+docker compose exec app php artisan test --testsuite=Feature
 ```
 
 ### Coverage Included:
@@ -44,6 +44,6 @@ docker-compose exec app php artisan test --testsuite=Feature
 
 ## 🛠️ Manual Maintenance
 
-- **Restart Services**: `docker-compose restart`
-- **View Logs**: `docker-compose logs -f`
+- **Restart Services**: `docker compose restart`
+- **View Logs**: `docker compose logs -f`
 - **Database Access**: [http://localhost:8080](http://localhost:8080)


### PR DESCRIPTION
Replace deprecated 'docker-compose' (hyphenated) commands with modern 'docker compose' (space) syntax across all documentation files to match the current Docker Compose V2 standard.

Files updated:
- README.md: Quick Start installation commands
- docs/INSTALLATION.md: Testing and manual maintenance commands
- CRUSH.md: Backend development commands