### PR TITLE
Remove outdated docker-compose references

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,8 @@ set -e
 echo "🏗️  Starting SteelFlow MRP Installation..."
 
 # 1. Check for Docker
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo '❌ Error: docker-compose is not installed. Please install Docker Desktop for Windows and enable WSL2 integration.' >&2
+if ! [ -x "$(command -v docker)" ]; then
+  echo '❌ Error: docker is not installed. Please install Docker Desktop for Windows and enable WSL2 integration.' >&2
   exit 1
 fi
 
@@ -20,17 +20,17 @@ fi
 
 # 3. Launch Docker containers
 echo "🐳 Launching Docker containers..."
-docker-compose up -d --build
+docker compose up -d --build
 
 # 4. Wait for MySQL to be ready
 echo "⏳ Waiting for MySQL to initialize..."
-until docker-compose exec mysql mysqladmin ping -h"localhost" --silent; do
+until docker compose exec mysql mysqladmin ping -h"localhost" --silent; do
     sleep 2
 done
 
 # 5. Install PHP Dependencies
 echo "📦 Installing PHP dependencies..."
-docker-compose exec app composer install
+docker compose exec app composer install
 
 # 6. Install Frontend Dependencies
 if [ -x "$(command -v npm)" ]; then
@@ -43,11 +43,11 @@ fi
 
 # 7. Application Setup
 echo "🔑 Finalizing application configuration..."
-docker-compose exec app php artisan key:generate
-docker-compose exec app php artisan migrate --force --seed
+docker compose exec app php artisan key:generate
+docker compose exec app php artisan migrate --force --seed
 
 # 8. Success
 echo "✅ SteelFlow MRP is now installed!"
 echo "🌐 App URL: http://localhost"
 echo "🔧 phpMyAdmin: http://localhost:8080 (User: root / Pass: ${DB_PASSWORD:-secret})"
-echo "🧪 To run tests: docker-compose exec app php artisan test"
+echo "🧪 To run tests: docker compose exec app php artisan test"


### PR DESCRIPTION
Update all docker-compose V1 command references to docker compose V2 syntax in scripts/install.sh. This includes:
- Docker availability check
- Container launch command
- MySQL health check
- Composer install
- Artisan commands
- Test execution instructions