### PR TITLE
Fix remaining permissions issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     libzip-dev \
+    su-exec \
     && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -24,8 +25,15 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 # Set working directory
 WORKDIR /var/www
 
-# Configure git to trust /var/www directory (fixes ownership issues with mounted volumes)
-RUN git config --global --add safe.directory /var/www
+# Copy entrypoint script
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# Switch to non-root user
-USER www-data
+# Configure git to trust /var/www directory at system level
+RUN git config --system --add safe.directory /var/www
+
+# Set entrypoint to handle permissions
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# Default command for php-fpm
+CMD ["php-fpm"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Configure git safe directory for www-data user
+if [ "$(id -u)" = "0" ]; then
+    # Running as root - configure git and fix permissions
+    git config --system --add safe.directory /var/www
+
+    # Ensure composer cache directory exists and has proper permissions
+    mkdir -p /var/www/.composer/cache
+    chown -R www-data:www-data /var/www/.composer 2>/dev/null || true
+
+    # Create storage and bootstrap cache directories if they don't exist
+    mkdir -p /var/www/storage /var/www/bootstrap/cache
+    chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache 2>/dev/null || true
+
+    # Execute the main command as www-data
+    exec su-exec www-data "$@"
+else
+    # Already running as www-data
+    git config --global --add safe.directory /var/www 2>/dev/null || true
+    exec "$@"
+fi


### PR DESCRIPTION
- Add entrypoint script to handle permissions at runtime
- Configure git safe.directory at system level
- Install su-exec for proper user switching
- Ensure composer cache directory has correct permissions
- Create storage and bootstrap cache directories with proper ownership

This resolves:
- "repository does not have correct ownership" git errors
- Composer cache write permission issues
- Runtime permission conflicts with www-data user