### PR TITLE
Resolve new errors in codebase

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     libzip-dev \
-    su-exec \
+    gosu \
     && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "$(id -u)" = "0" ]; then
     chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache 2>/dev/null || true
 
     # Execute the main command as www-data
-    exec su-exec www-data "$@"
+    exec gosu www-data "$@"
 else
     # Already running as www-data
     git config --global --add safe.directory /var/www 2>/dev/null || true


### PR DESCRIPTION
- su-exec is an Alpine Linux package, not available in Debian
- gosu is the Debian/Ubuntu equivalent
- Updated both Dockerfile and entrypoint.sh to use gosu