### PR TITLE
Fix tiny error

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,21 +3,20 @@ set -e
 
 # Configure git safe directory for www-data user
 if [ "$(id -u)" = "0" ]; then
-    # Running as root - configure git and fix permissions
-    git config --system --add safe.directory /var/www
+    # Running as root - fix permissions
+    # Ensure directories exist
+    mkdir -p /var/www/.composer/cache 2>/dev/null || true
+    mkdir -p /var/www/storage 2>/dev/null || true
+    mkdir -p /var/www/bootstrap/cache 2>/dev/null || true
 
-    # Ensure composer cache directory exists and has proper permissions
-    mkdir -p /var/www/.composer/cache
-    chown -R www-data:www-data /var/www/.composer 2>/dev/null || true
-
-    # Create storage and bootstrap cache directories if they don't exist
-    mkdir -p /var/www/storage /var/www/bootstrap/cache
-    chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache 2>/dev/null || true
+    # Fix ownership if directories exist
+    [ -d /var/www/.composer ] && chown -R www-data:www-data /var/www/.composer 2>/dev/null || true
+    [ -d /var/www/storage ] && chown -R www-data:www-data /var/www/storage 2>/dev/null || true
+    [ -d /var/www/bootstrap/cache ] && chown -R www-data:www-data /var/www/bootstrap/cache 2>/dev/null || true
 
     # Execute the main command as www-data
     exec gosu www-data "$@"
 else
     # Already running as www-data
-    git config --global --add safe.directory /var/www 2>/dev/null || true
     exec "$@"
 fi


### PR DESCRIPTION
Simplified entrypoint script to avoid broken pipe errors by:
- Removing redundant git config command (already in Dockerfile)
- Adding conditional checks before chown operations
- Improving error handling for directory operations