### PR TITLE
Fix app restart issue

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,21 @@
 
 # Only fix permissions if running as root
 if [ "$(id -u)" = "0" ]; then
+    # Check if .env file exists, if not copy from .env.example
+    if [ ! -f /var/www/.env ] && [ -f /var/www/.env.example ]; then
+        echo "Creating .env file from .env.example..."
+        cp /var/www/.env.example /var/www/.env
+    fi
+
+    # Generate APP_KEY if it's empty or missing
+    if [ -f /var/www/.env ]; then
+        if ! grep -q "^APP_KEY=base64:" /var/www/.env; then
+            echo "Generating application key..."
+            APP_KEY=$(php -r "echo 'base64:' . base64_encode(random_bytes(32));")
+            sed -i "s|^APP_KEY=.*|APP_KEY=$APP_KEY|" /var/www/.env
+        fi
+    fi
+
     # Create necessary directories if they don't exist
     for dir in /var/www/.composer/cache /var/www/storage /var/www/bootstrap/cache; do
         if [ ! -d "$dir" ]; then
@@ -13,6 +28,7 @@ if [ "$(id -u)" = "0" ]; then
     chown -R www-data:www-data /var/www/.composer 2>/dev/null || true
     chown -R www-data:www-data /var/www/storage 2>/dev/null || true
     chown -R www-data:www-data /var/www/bootstrap/cache 2>/dev/null || true
+    chown www-data:www-data /var/www/.env 2>/dev/null || true
 
     # Drop privileges and execute command
     exec gosu www-data "$@"


### PR DESCRIPTION
The application was stuck in a restart loop because:
- Missing .env file caused Laravel to fail on boot
- Empty APP_KEY in .env caused encryption errors

Changes:
- Updated entrypoint.sh to automatically create .env from .env.example if missing
- Added automatic APP_KEY generation if not set
- Added .env file ownership fix to www-data user
- Created .env file with generated APP_KEY for immediate fix

The entrypoint script now handles these initialization tasks automatically, preventing future restart issues when containers are recreated.

To apply the fix:
1. Restart the containers: docker compose restart app OR
2. Rebuild and restart: docker compose down && docker compose up -d

Fixes the container restart loop issue.