### PR TITLE
Fix Docker build error for steelflow-app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   app:
     build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,5 +35,5 @@ RUN git config --system --add safe.directory /var/www
 # Set entrypoint to handle permissions
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-# Default command for php-fpm
-CMD ["php-fpm"]
+# Default command for php-fpm (run in foreground to prevent container exit)
+CMD ["php-fpm", "-F"]


### PR DESCRIPTION
Changes:
- Modified Dockerfile to run php-fpm with -F flag (foreground mode)
- This prevents php-fpm from daemonizing and causing container to exit/restart
- Removed obsolete version attribute from docker-compose.yml to eliminate warnings

This fixes the "Container is restarting" error that occurred when trying to run composer install during the update.sh script execution.