### PR TITLE
Fix manifest export error in build process

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,10 +29,7 @@ if [ "$(id -u)" = "0" ]; then
     chown -R www-data:www-data /var/www/storage 2>/dev/null || true
     chown -R www-data:www-data /var/www/bootstrap/cache 2>/dev/null || true
     chown www-data:www-data /var/www/.env 2>/dev/null || true
-
-    # Drop privileges and execute command
-    exec gosu www-data "$@"
 fi
 
-# If not root, just execute the command
+# Execute command as root (php-fpm will drop privileges for worker processes)
 exec "$@"


### PR DESCRIPTION
The container was restarting when trying to execute composer commands. The issue was that php-fpm was being run as www-data via gosu, which prevented it from properly managing worker processes.

Changes:
- Removed gosu wrapper that was running php-fpm as www-data
- PHP-FPM now runs as root (master process) and automatically drops privileges to www-data for worker processes (default behavior)
- This is the standard pattern for running php-fpm in Docker containers
- Directory permissions are still fixed for www-data before php-fpm starts

This allows the container to remain stable when composer and other commands are executed via docker compose exec.