### PR TITLE
Align PHP requirement with locked dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [Roadmap & Progress](#️-roadmap--progress) section below for detailed 
 ## 🛠️ The SteelFlow Stack
 
 ### **Backend Core**
-- **Framework**: Laravel 11 (PHP 8.3+)
+- **Framework**: Laravel 11 (PHP 8.4+)
 - **Database**: MySQL 8.0 / PostgreSQL
 - **Cache/Queue**: Redis + Laravel Horizon
 - **Search Engine**: Meilisearch for sub-millisecond lookups

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["laravel", "mrp", "manufacturing", "steel", "fabrication"],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "guzzlehttp/guzzle": "^7.8",
         "inertiajs/inertia-laravel": "^1.0",
         "laravel/framework": "^11.0",
@@ -66,6 +66,9 @@
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
+        "platform": {
+            "php": "8.4.0"
+        },
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -13,7 +13,7 @@ chmod +x scripts/install.sh && ./scripts/install.sh
 ### What This Script Does:
 1. **Environment Initialization**: Creates `.env` from `.env.example`.
 2. **Infrastructure Launch**: Boots Docker containers for:
-   - **PHP 8.3 FPM** (Application Logic)
+   - **PHP 8.4 FPM** (Application Logic)
    - **Nginx** (Web Server)
    - **MySQL 8.0** (Primary Database)
    - **Redis** (Queue & Cache)


### PR DESCRIPTION
## Summary
- Raise the PHP requirement and platform configuration to 8.4 to match the locked Symfony components
- Update README and installation docs to call out PHP 8.4 as the supported runtime
- Note: Dependency set unchanged; lock refresh may be run when packagist access is available if desired

## Testing
- composer validate --no-check-publish (warns that composer.lock needs a refresh after updating composer.json)【a3384a†L1-L4】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d011817883249e56963357f547d2)