### PR TITLE
Add Node support to app container for frontend build automation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,17 +4,22 @@ FROM php:8.3-fpm
 LABEL maintainer="SteelFlow MRP"
 LABEL version="2.0"
 
-# Install system dependencies and PHP extensions in a single layer
+# Install system dependencies, Node.js (for frontend builds), and PHP extensions in a single layer
 RUN apt-get update && apt-get install -y \
-    git \
+    ca-certificates \
     curl \
-    libpng-dev \
+    git \
+    gnupg \
     libonig-dev \
+    libpng-dev \
     libxml2-dev \
-    zip \
-    unzip \
     libzip-dev \
+    unzip \
+    zip \
     gosu \
+    # Add NodeSource repository for Node.js 20 (needed to build the Vue frontend inside the container)
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
     && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,13 +32,13 @@ done
 echo "📦 Installing PHP dependencies..."
 docker compose exec app composer install
 
-# 6. Install Frontend Dependencies
-if [ -x "$(command -v npm)" ]; then
-    echo "🎨 Installing Frontend dependencies..."
-    npm install
-    npm run build
+# 6. Install Frontend Dependencies inside the app container (Node is bundled in the image)
+if docker compose exec app command -v npm > /dev/null 2>&1; then
+    echo "🎨 Installing Frontend dependencies inside container..."
+    docker compose exec app npm install
+    docker compose exec app npm run build
 else
-    echo "⚠️  npm not found locally. Skipping frontend build. Run npm manually inside WSL2."
+    echo "⚠️  npm is not available in the app container. Please ensure the image built correctly."
 fi
 
 # 7. Application Setup

--- a/update.sh
+++ b/update.sh
@@ -130,11 +130,15 @@ status "Updating PHP dependencies..."
 docker compose exec app composer install --no-interaction --prefer-dist --optimize-autoloader
 success "PHP dependencies updated"
 
-# Step 8: Update frontend dependencies
+# Step 8: Update frontend dependencies inside the app container
 if [ -f "package.json" ]; then
-    status "Updating frontend dependencies..."
-    npm install
-    success "Frontend dependencies updated"
+    status "Updating frontend dependencies inside container..."
+    if docker compose exec app command -v npm > /dev/null 2>&1; then
+        docker compose exec app npm install
+        success "Frontend dependencies updated"
+    else
+        warning "npm is unavailable in the app container - check the Docker build"
+    fi
 else
     warning "No package.json found - skipping npm install"
 fi
@@ -180,11 +184,15 @@ docker compose exec app php artisan route:cache
 docker compose exec app php artisan view:cache
 success "Application optimized"
 
-# Step 14: Build frontend assets
+# Step 14: Build frontend assets inside the container
 if [ -f "package.json" ]; then
-    status "Building frontend assets..."
-    npm run build
-    success "Frontend assets built"
+    status "Building frontend assets inside container..."
+    if docker compose exec app command -v npm > /dev/null 2>&1; then
+        docker compose exec app npm run build
+        success "Frontend assets built"
+    else
+        warning "npm is unavailable in the app container - skipping asset build"
+    fi
 fi
 
 # Step 15: Set proper permissions


### PR DESCRIPTION
## Summary
- install Node.js 20 in the PHP app container so frontend assets can be built in Docker
- run frontend dependency installation and asset builds inside the app container during install/update scripts

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69572e69bc9083249bb1ea8e698c604b)