### PR TITLE
Add contextual logging across imports and production workflows

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -1,9 +1,11 @@
 <?php
+// app/Http/Controllers/ProductionController.php
 
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Services\ProductionService;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class ProductionController extends Controller
@@ -23,6 +25,11 @@ class ProductionController extends Controller
     public function processScan(Request $request)
     {
         $barcode = $request->input('barcode');
+        Log::info('Production barcode scanned', [
+            'barcode' => $barcode,
+            'user_id' => $request->user()?->id,
+        ]);
+
         // Logic to parse barcode and update production/inventory
         // For now, just return a success message
         return back()->with('success', 'Processed barcode: ' . $barcode);

--- a/app/Http/Middleware/RequestContextMiddleware.php
+++ b/app/Http/Middleware/RequestContextMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+// app/Http/Middleware/RequestContextMiddleware.php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class RequestContextMiddleware
+{
+    /**
+     * Attach contextual data to every log line and record request lifecycle timing.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $requestId = Str::uuid()->toString();
+        $startTime = microtime(true);
+
+        Log::withContext([
+            'request_id' => $requestId,
+            'ip' => $request->ip(),
+            'user_id' => $request->user()?->id,
+            'route' => optional($request->route())->getName(),
+        ]);
+
+        Log::info('Incoming request received', [
+            'method' => $request->method(),
+            'path' => $request->path(),
+            'query' => $request->query(),
+        ]);
+
+        try {
+            $response = $next($request);
+        } catch (\Throwable $exception) {
+            Log::error('Request handling failed', [
+                'message' => $exception->getMessage(),
+                'exception_class' => $exception::class,
+                'trace_sample' => collect(explode(PHP_EOL, $exception->getTraceAsString()))
+                    ->take(5)
+                    ->toArray(),
+            ]);
+
+            throw $exception;
+        }
+
+        $durationMs = round((microtime(true) - $startTime) * 1000, 2);
+
+        Log::info('Response dispatched', [
+            'status' => $response->getStatusCode(),
+            'duration_ms' => $durationMs,
+            'response_type' => get_class($response),
+        ]);
+
+        return $response;
+    }
+}

--- a/app/Services/Import/KissImporter.php
+++ b/app/Services/Import/KissImporter.php
@@ -1,4 +1,5 @@
 <?php
+// app/Services/Import/KissImporter.php
 
 namespace App\Services\Import;
 
@@ -9,10 +10,15 @@ use App\Services\ReferenceDataService;
 use App\Services\Pricing\WeightCalculator;
 use App\Services\BOMExtensionService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class KissImporter
 {
     protected array $errors = [];
+    protected string $operationId;
+    protected int $assemblyCount = 0;
+    protected int $partCount = 0;
 
     public function __construct(
         protected ReferenceDataService $referenceData,
@@ -25,31 +31,78 @@ class KissImporter
      */
     public function import(string $filePath, Project $project): bool
     {
+        $this->errors = [];
+        $this->operationId = Str::uuid()->toString();
+        $this->assemblyCount = 0;
+        $this->partCount = 0;
+
+        Log::info('Starting KISS import', [
+            'operation_id' => $this->operationId,
+            'project_id' => $project->id,
+            'file' => $filePath,
+        ]);
+
         if (!file_exists($filePath)) {
-            $this->errors[] = "File not found: " . $filePath;
+            $message = "File not found: " . $filePath;
+            $this->errors[] = $message;
+            Log::error('KISS import failed - file missing', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'file' => $filePath,
+            ]);
             return false;
         }
 
         $lines = file($filePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        
+        if ($lines === false) {
+            $message = "Unable to read file: " . $filePath;
+            $this->errors[] = $message;
+            Log::error('KISS import failed - unreadable file', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'file' => $filePath,
+            ]);
+            return false;
+        }
+
         $success = DB::transaction(function () use ($lines, $project) {
-            foreach ($lines as $line) {
-                $this->processLine($line, $project);
+            foreach ($lines as $index => $line) {
+                $this->processLine($line, $project, $index + 1);
             }
             return true;
         });
 
         if ($success) {
             $this->bomExtensionService->extendProject($project);
+            Log::info('KISS import completed', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'assemblies_processed' => $this->assemblyCount,
+                'parts_processed' => $this->partCount,
+                'errors' => $this->errors,
+            ]);
+        } else {
+            Log::error('KISS import transaction failed', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'errors' => $this->errors,
+            ]);
         }
 
         return $success;
     }
 
-    protected function processLine(string $line, Project $project): void
+    protected function processLine(string $line, Project $project, int $lineNumber = 0): void
     {
         $data = str_getcsv($line, ',');
         $type = strtoupper(trim($data[0] ?? ''));
+
+        Log::debug('Processing KISS line', [
+            'operation_id' => $this->operationId,
+            'project_id' => $project->id,
+            'line_number' => $lineNumber,
+            'type' => $type,
+        ]);
 
         switch ($type) {
             case 'SHP':
@@ -58,6 +111,15 @@ class KissImporter
             case 'DET':
                 $this->importPart($data, $project);
                 break;
+            default:
+                Log::warning('Unknown KISS record type encountered', [
+                    'operation_id' => $this->operationId,
+                    'project_id' => $project->id,
+                    'line_number' => $lineNumber,
+                    'raw' => $line,
+                ]);
+                $this->errors[] = "Unknown record type at line {$lineNumber}";
+                break;
         }
     }
 
@@ -65,9 +127,15 @@ class KissImporter
     {
         // Reference: SHP, Mark, Qty, Description, WeightEach, WeightTotal, Remark, Drawing
         $mark = trim($data[1] ?? '');
-        if (!$mark) return;
+        if (!$mark) {
+            Log::warning('Skipping assembly with empty mark', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+            ]);
+            return;
+        }
 
-        Assembly::updateOrCreate(
+        $assembly = Assembly::updateOrCreate(
             [
                 'project_id' => $project->id,
                 'mark' => $mark,
@@ -81,6 +149,16 @@ class KissImporter
                 'total_weight_kg' => (float) ($data[5] ?? 0) * 0.453592,
             ]
         );
+
+        $this->assemblyCount++;
+
+        Log::info('Assembly processed from KISS import', [
+            'operation_id' => $this->operationId,
+            'project_id' => $project->id,
+            'assembly_id' => $assembly->id,
+            'mark' => $mark,
+            'quantity' => (int) ($data[2] ?? 1),
+        ]);
     }
 
     protected function importPart(array $data, Project $project): void
@@ -95,6 +173,12 @@ class KissImporter
 
         if (!$assembly) {
             $this->errors[] = "Assembly $assemblyMark not found for part $partMark";
+            Log::warning('KISS import unable to locate assembly', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'assembly_mark' => $assemblyMark,
+                'part_mark' => $partMark,
+            ]);
             return;
         }
 
@@ -123,10 +207,30 @@ class KissImporter
             ]
         );
 
+        $this->partCount++;
+
+        Log::info('Part processed from KISS import', [
+            'operation_id' => $this->operationId,
+            'project_id' => $project->id,
+            'part_id' => $part->id,
+            'assembly_id' => $assembly->id,
+            'part_mark' => $partMark,
+            'quantity' => (int) ($data[3] ?? 1),
+            'material_type' => $materialType,
+            'length' => $length,
+        ]);
+
         // Recalculate weights if zero provided in file
         if ($part->weight_each_lbs <= 0 && $material) {
             $weights = $this->weightCalculator->calculatePartWeights($part);
             $part->update($weights);
+
+            Log::info('Part weight recalculated during KISS import', [
+                'operation_id' => $this->operationId,
+                'project_id' => $project->id,
+                'part_id' => $part->id,
+                'updated_weights' => $weights,
+            ]);
         }
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,4 +1,5 @@
 <?php
+// bootstrap/app.php
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -11,9 +12,14 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->web(append: [
-            \App\Http\Middleware\HandleInertiaRequests::class,
-        ]);
+        $middleware->web(
+            prepend: [
+                \App\Http\Middleware\RequestContextMiddleware::class,
+            ],
+            append: [
+                \App\Http\Middleware\HandleInertiaRequests::class,
+            ],
+        );
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,4 +1,5 @@
 <?php
+// config/logging.php
 
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
@@ -33,7 +34,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', env('LOG_STACK', 'single')),
+            'channels' => explode(',', env('LOG_STACK', 'single,operations')),
             'ignore_exceptions' => false,
         ],
 
@@ -104,6 +105,14 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        'operations' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/operations.log'),
+            'level' => env('OPERATIONS_LOG_LEVEL', 'info'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
         ],
 
     ],


### PR DESCRIPTION
## Summary
- add an operations logging channel and request context middleware to capture request metadata
- instrument KISS/XSR importers, inventory receiving, and production services with detailed operational logs
- log production barcode scans and ensure logging middleware is registered in the web stack

## Testing
- php -l config/logging.php bootstrap/app.php app/Http/Middleware/RequestContextMiddleware.php app/Services/Import/KissImporter.php app/Services/Import/XsrImporter.php app/Services/InventoryService.php app/Services/Production/ProductionService.php app/Http/Controllers/ProductionController.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957461d7b9083249dfe8ab79e7b6f1b)