### PR TITLE
Fix PHP extension dependencies in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,12 +9,16 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libwebp-dev \
     libonig-dev \
     libxml2-dev \
     zip \
     unzip \
     libzip-dev \
     gosu \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add missing image libraries required for gd extension
- configure gd to build with freetype, jpeg, and webp support
- retain existing PHP extensions and cleanup

## Testing
- docker build -f docker/Dockerfile . *(fails: docker not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959cb7c874c8324a8f3947b7742718f)