### PR TITLE
Fix Docker PHP installation errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm
+FROM php:8.4-fpm
 
 # Set labels
 LABEL maintainer="SteelFlow MRP"
@@ -14,17 +14,41 @@ RUN apt-get update && apt-get install -y \
     libwebp-dev \
     libonig-dev \
     libxml2-dev \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    libsodium-dev \
     zip \
     unzip \
     libzip-dev \
     gosu \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install -j$(nproc) \
+        pdo_mysql \
+        mbstring \
+        exif \
+        pcntl \
+        bcmath \
+        gd \
+        zip \
+        intl \
+        curl \
+        dom \
+        xml \
+        xmlreader \
+        xmlwriter \
+        sodium \
+        opcache \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Get latest Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Copy PHP configuration
+COPY docker/php.ini $PHP_INI_DIR/conf.d/99-custom.ini
 
 # Set working directory
 WORKDIR /var/www

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,28 @@
+[PHP]
+; Maximum execution time of each script, in seconds
+max_execution_time = 120
+
+; Maximum amount of memory a script may consume
+memory_limit = 512M
+
+; Maximum size of POST data that PHP will accept
+post_max_size = 100M
+
+; Maximum allowed size for uploaded files
+upload_max_filesize = 100M
+
+; OPcache settings for production performance
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.validate_timestamps=0
+opcache.save_comments=1
+opcache.fast_shutdown=1
+
+; Redis session handler (optional, uncomment if needed)
+; [Session]
+; session.save_handler = redis
+; session.save_path = "tcp://redis:6379"


### PR DESCRIPTION
- Upgrade base image from PHP 8.3 to 8.4 to match composer.json requirements
- Add Redis extension via PECL for better performance (used for cache/queue/session)
- Add intl extension for internationalization support
- Add curl, dom, xml, xmlreader, xmlwriter, sodium extensions for Laravel 11
- Enable OPcache for production performance optimization
- Add production-ready PHP configuration with optimized OPcache settings
- Use parallel compilation with -j$(nproc) for faster builds
- Install required development libraries: libicu-dev, libcurl4-openssl-dev, libsodium-dev

This fixes compatibility issues and ensures all Laravel 11 requirements are met.