### PR TITLE
Convert fields to dropdowns and split length

### DIFF
--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreStockItemRequest;
 use App\Http\Requests\UpdateStockItemRequest;
+use App\Models\Grade;
 use App\Models\Material;
 use App\Models\Project;
 use App\Models\StockItem;
@@ -42,6 +43,9 @@ class InventoryController extends Controller
             'projects' => $projects,
             'statuses' => $this->getStatuses(),
             'stockAreas' => $this->getStockAreas(),
+            'types' => $this->getUniqueTypes(),
+            'sizesByType' => $this->getSizesByType(),
+            'grades' => $this->getGrades(),
         ]);
     }
 
@@ -96,6 +100,9 @@ class InventoryController extends Controller
             'projects' => $projects,
             'statuses' => $this->getStatuses(),
             'stockAreas' => $this->getStockAreas(),
+            'types' => $this->getUniqueTypes(),
+            'sizesByType' => $this->getSizesByType(),
+            'grades' => $this->getGrades(),
         ]);
     }
 
@@ -168,5 +175,50 @@ class InventoryController extends Controller
     protected function generateStockId(): string
     {
         return 'STK-'.strtoupper(uniqid());
+    }
+
+    /**
+     * Get unique material types.
+     */
+    protected function getUniqueTypes(): array
+    {
+        return Material::where('is_active', true)
+            ->distinct()
+            ->orderBy('type')
+            ->pluck('type')
+            ->toArray();
+    }
+
+    /**
+     * Get sizes grouped by type.
+     */
+    protected function getSizesByType(): array
+    {
+        $materials = Material::where('is_active', true)
+            ->orderBy('sort_order')
+            ->get(['type', 'size_imperial']);
+
+        $sizesByType = [];
+        foreach ($materials as $material) {
+            if (! isset($sizesByType[$material->type])) {
+                $sizesByType[$material->type] = [];
+            }
+            if ($material->size_imperial && ! in_array($material->size_imperial, $sizesByType[$material->type])) {
+                $sizesByType[$material->type][] = $material->size_imperial;
+            }
+        }
+
+        return $sizesByType;
+    }
+
+    /**
+     * Get all active grades.
+     */
+    protected function getGrades(): array
+    {
+        return Grade::where('is_active', true)
+            ->orderBy('code')
+            ->pluck('code')
+            ->toArray();
     }
 }

--- a/app/Http/Requests/StoreStockItemRequest.php
+++ b/app/Http/Requests/StoreStockItemRequest.php
@@ -20,10 +20,10 @@ class StoreStockItemRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'material_id' => ['required', 'exists:materials,id'],
-            'type' => ['nullable', 'string', 'max:50'],
-            'size' => ['nullable', 'string', 'max:50'],
-            'grade' => ['nullable', 'string', 'max:50'],
+            'material_id' => ['nullable', 'exists:materials,id'],
+            'type' => ['required', 'string', 'max:50'],
+            'size' => ['required', 'string', 'max:50'],
+            'grade' => ['required', 'string', 'max:50'],
             'length' => ['required', 'numeric', 'min:0'],
             'quantity' => ['required', 'integer', 'min:1'],
             'status' => ['required', 'string', 'in:free,assigned,committed,used'],
@@ -44,8 +44,10 @@ class StoreStockItemRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'material_id.required' => 'Please select a material.',
             'material_id.exists' => 'The selected material does not exist.',
+            'type.required' => 'Please select a type.',
+            'size.required' => 'Please select a size.',
+            'grade.required' => 'Please select a grade.',
             'length.required' => 'Length is required.',
             'quantity.required' => 'Quantity is required.',
             'quantity.min' => 'Quantity must be at least 1.',

--- a/app/Http/Requests/UpdateStockItemRequest.php
+++ b/app/Http/Requests/UpdateStockItemRequest.php
@@ -20,10 +20,10 @@ class UpdateStockItemRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'material_id' => ['required', 'exists:materials,id'],
-            'type' => ['nullable', 'string', 'max:50'],
-            'size' => ['nullable', 'string', 'max:50'],
-            'grade' => ['nullable', 'string', 'max:50'],
+            'material_id' => ['nullable', 'exists:materials,id'],
+            'type' => ['required', 'string', 'max:50'],
+            'size' => ['required', 'string', 'max:50'],
+            'grade' => ['required', 'string', 'max:50'],
             'length' => ['required', 'numeric', 'min:0'],
             'quantity' => ['required', 'integer', 'min:0'],
             'status' => ['required', 'string', 'in:free,assigned,committed,used'],
@@ -44,8 +44,10 @@ class UpdateStockItemRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'material_id.required' => 'Please select a material.',
             'material_id.exists' => 'The selected material does not exist.',
+            'type.required' => 'Please select a type.',
+            'size.required' => 'Please select a size.',
+            'grade.required' => 'Please select a grade.',
             'length.required' => 'Length is required.',
             'quantity.required' => 'Quantity is required.',
             'status.in' => 'Invalid status.',

--- a/resources/js/Pages/Inventory/Create.vue
+++ b/resources/js/Pages/Inventory/Create.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed, watch } from 'vue';
 import { useForm, Link } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 
@@ -7,6 +8,9 @@ const props = defineProps({
     projects: Array,
     statuses: Object,
     stockAreas: Object,
+    types: Array,
+    sizesByType: Object,
+    grades: Array,
 });
 
 const form = useForm({
@@ -14,7 +18,8 @@ const form = useForm({
     type: '',
     size: '',
     grade: '',
-    length: '',
+    length_ft: '',
+    length_in: '',
     quantity: 1,
     status: 'free',
     reserved_project_id: '',
@@ -27,17 +32,36 @@ const form = useForm({
     notes: '',
 });
 
+// Computed property for available sizes based on selected type
+const availableSizes = computed(() => {
+    if (!form.type || !props.sizesByType[form.type]) {
+        return [];
+    }
+    return props.sizesByType[form.type];
+});
+
+// Reset size when type changes
+watch(() => form.type, () => {
+    form.size = '';
+});
+
 const onMaterialChange = () => {
     const material = props.materials.find(m => m.id === parseInt(form.material_id));
     if (material) {
         form.type = material.type;
-        form.size = material.size;
-        form.grade = material.grade;
+        form.size = material.size_imperial || material.size_metric;
+        form.grade = material.grade?.code || '';
     }
 };
 
 const submit = () => {
-    form.post('/inventory');
+    // Convert feet and inches to total feet before submitting
+    const totalFeet = (parseFloat(form.length_ft) || 0) + ((parseFloat(form.length_in) || 0) / 12);
+
+    form.transform((data) => ({
+        ...data,
+        length: totalFeet,
+    })).post('/inventory');
 };
 </script>
 
@@ -85,7 +109,7 @@ const submit = () => {
                 :key="material.id"
                 :value="material.id"
               >
-                {{ material.description }}
+                {{ material.type }} {{ material.size_imperial || material.size_metric }}
               </option>
             </select>
           </div>
@@ -98,14 +122,23 @@ const submit = () => {
             >
               Type *
             </label>
-            <input
+            <select
               id="type"
               v-model="form.type"
-              type="text"
               required
-              placeholder="e.g., W, C, L, HSS"
               class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             >
+              <option value="">
+                Select Type
+              </option>
+              <option
+                v-for="type in types"
+                :key="type"
+                :value="type"
+              >
+                {{ type }}
+              </option>
+            </select>
             <p
               v-if="form.errors.type"
               class="mt-1 text-sm text-red-600"
@@ -122,14 +155,24 @@ const submit = () => {
             >
               Size *
             </label>
-            <input
+            <select
               id="size"
               v-model="form.size"
-              type="text"
               required
-              placeholder="e.g., W14x30, C10x15.3"
-              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              :disabled="!form.type"
+              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50"
             >
+              <option value="">
+                {{ form.type ? 'Select Size' : 'Select Type First' }}
+              </option>
+              <option
+                v-for="size in availableSizes"
+                :key="size"
+                :value="size"
+              >
+                {{ size }}
+              </option>
+            </select>
             <p
               v-if="form.errors.size"
               class="mt-1 text-sm text-red-600"
@@ -146,14 +189,23 @@ const submit = () => {
             >
               Grade *
             </label>
-            <input
+            <select
               id="grade"
               v-model="form.grade"
-              type="text"
               required
-              placeholder="e.g., A992, A36"
               class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             >
+              <option value="">
+                Select Grade
+              </option>
+              <option
+                v-for="grade in grades"
+                :key="grade"
+                :value="grade"
+              >
+                {{ grade }}
+              </option>
+            </select>
             <p
               v-if="form.errors.grade"
               class="mt-1 text-sm text-red-600"
@@ -162,23 +214,47 @@ const submit = () => {
             </p>
           </div>
 
-          <!-- Length -->
+          <!-- Length (Feet and Inches) -->
           <div>
-            <label
-              for="length"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Length (ft) *
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Length *
             </label>
-            <input
-              id="length"
-              v-model="form.length"
-              type="number"
-              step="0.01"
-              min="0"
-              required
-              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-            >
+            <div class="mt-1 flex space-x-2">
+              <div class="flex-1">
+                <div class="relative">
+                  <input
+                    id="length_ft"
+                    v-model="form.length_ft"
+                    type="number"
+                    min="0"
+                    step="1"
+                    required
+                    placeholder="0"
+                    class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 pr-8"
+                  >
+                  <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 dark:text-gray-400 text-sm">
+                    ft
+                  </span>
+                </div>
+              </div>
+              <div class="flex-1">
+                <div class="relative">
+                  <input
+                    id="length_in"
+                    v-model="form.length_in"
+                    type="number"
+                    min="0"
+                    max="11"
+                    step="1"
+                    placeholder="0"
+                    class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 pr-8"
+                  >
+                  <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 dark:text-gray-400 text-sm">
+                    in
+                  </span>
+                </div>
+              </div>
+            </div>
             <p
               v-if="form.errors.length"
               class="mt-1 text-sm text-red-600"

--- a/resources/js/Pages/Inventory/Edit.vue
+++ b/resources/js/Pages/Inventory/Edit.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { ref, computed, watch } from 'vue';
 import { useForm, Link, router } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 
@@ -8,14 +9,23 @@ const props = defineProps({
     projects: Array,
     statuses: Object,
     stockAreas: Object,
+    types: Array,
+    sizesByType: Object,
+    grades: Array,
 });
+
+// Convert total feet to feet and inches
+const totalLength = parseFloat(props.stockItem.length) || 0;
+const initialFeet = Math.floor(totalLength);
+const initialInches = Math.round((totalLength - initialFeet) * 12);
 
 const form = useForm({
     material_id: props.stockItem.material_id || '',
     type: props.stockItem.type,
     size: props.stockItem.size,
     grade: props.stockItem.grade,
-    length: props.stockItem.length,
+    length_ft: initialFeet,
+    length_in: initialInches,
     quantity: props.stockItem.quantity,
     status: props.stockItem.status,
     reserved_project_id: props.stockItem.reserved_project_id || '',
@@ -28,8 +38,33 @@ const form = useForm({
     notes: props.stockItem.notes || '',
 });
 
+// Computed property for available sizes based on selected type
+const availableSizes = computed(() => {
+    if (!form.type || !props.sizesByType[form.type]) {
+        return [];
+    }
+    return props.sizesByType[form.type];
+});
+
+// Track if we should reset size on type change (only for user-initiated changes)
+const isInitialLoad = ref(true);
+
+watch(() => form.type, (newType, oldType) => {
+    // Only reset size if it's not the initial load and the type actually changed
+    if (!isInitialLoad.value && oldType !== newType) {
+        form.size = '';
+    }
+    isInitialLoad.value = false;
+});
+
 const submit = () => {
-    form.put(`/inventory/${props.stockItem.id}`);
+    // Convert feet and inches to total feet before submitting
+    const totalFeet = (parseFloat(form.length_ft) || 0) + ((parseFloat(form.length_in) || 0) / 12);
+
+    form.transform((data) => ({
+        ...data,
+        length: totalFeet,
+    })).put(`/inventory/${props.stockItem.id}`);
 };
 
 const deleteItem = () => {
@@ -78,13 +113,23 @@ const deleteItem = () => {
             >
               Type *
             </label>
-            <input
+            <select
               id="type"
               v-model="form.type"
-              type="text"
               required
               class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             >
+              <option value="">
+                Select Type
+              </option>
+              <option
+                v-for="type in types"
+                :key="type"
+                :value="type"
+              >
+                {{ type }}
+              </option>
+            </select>
             <p
               v-if="form.errors.type"
               class="mt-1 text-sm text-red-600"
@@ -101,13 +146,24 @@ const deleteItem = () => {
             >
               Size *
             </label>
-            <input
+            <select
               id="size"
               v-model="form.size"
-              type="text"
               required
-              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              :disabled="!form.type"
+              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50"
             >
+              <option value="">
+                {{ form.type ? 'Select Size' : 'Select Type First' }}
+              </option>
+              <option
+                v-for="size in availableSizes"
+                :key="size"
+                :value="size"
+              >
+                {{ size }}
+              </option>
+            </select>
             <p
               v-if="form.errors.size"
               class="mt-1 text-sm text-red-600"
@@ -124,13 +180,23 @@ const deleteItem = () => {
             >
               Grade *
             </label>
-            <input
+            <select
               id="grade"
               v-model="form.grade"
-              type="text"
               required
               class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             >
+              <option value="">
+                Select Grade
+              </option>
+              <option
+                v-for="grade in grades"
+                :key="grade"
+                :value="grade"
+              >
+                {{ grade }}
+              </option>
+            </select>
             <p
               v-if="form.errors.grade"
               class="mt-1 text-sm text-red-600"
@@ -139,23 +205,47 @@ const deleteItem = () => {
             </p>
           </div>
 
-          <!-- Length -->
+          <!-- Length (Feet and Inches) -->
           <div>
-            <label
-              for="length"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Length (ft) *
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Length *
             </label>
-            <input
-              id="length"
-              v-model="form.length"
-              type="number"
-              step="0.01"
-              min="0"
-              required
-              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-            >
+            <div class="mt-1 flex space-x-2">
+              <div class="flex-1">
+                <div class="relative">
+                  <input
+                    id="length_ft"
+                    v-model="form.length_ft"
+                    type="number"
+                    min="0"
+                    step="1"
+                    required
+                    placeholder="0"
+                    class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 pr-8"
+                  >
+                  <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 dark:text-gray-400 text-sm">
+                    ft
+                  </span>
+                </div>
+              </div>
+              <div class="flex-1">
+                <div class="relative">
+                  <input
+                    id="length_in"
+                    v-model="form.length_in"
+                    type="number"
+                    min="0"
+                    max="11"
+                    step="1"
+                    placeholder="0"
+                    class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 pr-8"
+                  >
+                  <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 dark:text-gray-400 text-sm">
+                    in
+                  </span>
+                </div>
+              </div>
+            </div>
             <p
               v-if="form.errors.length"
               class="mt-1 text-sm text-red-600"


### PR DESCRIPTION
…t/inches

- Convert Type, Size, and Grade fields from text inputs to dropdown selects
- Size dropdown filters based on selected Type
- Split Length field into separate Feet and Inches inputs
- Update InventoryController to pass types, sizesByType, and grades data
- Update validation rules to make type, size, grade required and material_id optional
- Apply changes to both Create.vue and Edit.vue pages