### PR TITLE
Enable persistent login support

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -66,7 +66,8 @@ class AuthController extends Controller
             'password' => bcrypt(Str::random(24)), // Random password for OAuth users
         ]);
 
-        Auth::login($user);
+        // Persist Azure SSO logins across browser sessions just like the standard "Remember me" flow
+        Auth::login($user, remember: true);
 
         return redirect()->intended('/dashboard');
     }

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -5,11 +5,17 @@ defineProps({
     status: String,
 });
 
-const form = useForm({
-    email: '',
-    password: '',
-    remember: false,
-});
+const form = useForm(
+    {
+        email: '',
+        password: '',
+        remember: false,
+    },
+    {
+        // Keep login details available across visits when the user opts in
+        remember: 'loginCredentials',
+    },
+);
 
 const submit = () => {
     form.post(route('login'), {


### PR DESCRIPTION
## Summary
- keep login form state across visits using Inertia's remember option
- persist Azure SSO sign-ins across browser sessions by enabling the remember flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7cb340a8832499bfa6a43224e49f)