### PR TITLE
Add ProductionItem workflow states and Filament resource

### DIFF
--- a/app/Filament/Resources/ProductionItemResource.php
+++ b/app/Filament/Resources/ProductionItemResource.php
@@ -1,0 +1,103 @@
+<?php // app/Filament/Resources/ProductionItemResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ProductionItemResource\Pages;
+use App\Models\ProductionItem;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Throwable;
+
+class ProductionItemResource extends Resource
+{
+    protected static ?string $model = ProductionItem::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('name')
+                ->label('Name')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\TextInput::make('part_number')
+                ->label('Part Number')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\Placeholder::make('status')
+                ->label('Status')
+                ->content(fn (?ProductionItem $record): string => $record?->displayStatus ?? 'Queued'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('part_number')
+                    ->label('Part Number')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('displayStatus')
+                    ->label('Status')
+                    ->badge()
+                    ->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('advanceStatus')
+                    ->label('Advance Status')
+                    ->icon('heroicon-m-arrow-right-circle')
+                    ->requiresConfirmation()
+                    ->disabled(fn (ProductionItem $record): bool => $record->nextStatus() === null)
+                    ->action(function (ProductionItem $record): void {
+                        $nextState = $record->nextStatus();
+
+                        if ($nextState === null) {
+                            Notification::make()
+                                ->title('Already shipped')
+                                ->warning()
+                                ->send();
+
+                            return;
+                        }
+
+                        try {
+                            $record->status->transitionTo($nextState);
+                            $record->save();
+
+                            Notification::make()
+                                ->title('Status advanced')
+                                ->success()
+                                ->send();
+                        } catch (Throwable $exception) {
+                            report($exception);
+
+                            Notification::make()
+                                ->title('Unable to advance status')
+                                ->body('Please try again.')
+                                ->danger()
+                                ->send();
+                        }
+                    }),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListProductionItems::route('/'),
+            'create' => Pages\CreateProductionItem::route('/create'),
+            'edit' => Pages\EditProductionItem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductionItemResource/Pages/CreateProductionItem.php
+++ b/app/Filament/Resources/ProductionItemResource/Pages/CreateProductionItem.php
@@ -1,0 +1,13 @@
+<?php // app/Filament/Resources/ProductionItemResource/Pages/CreateProductionItem.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ProductionItemResource\Pages;
+
+use App\Filament\Resources\ProductionItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateProductionItem extends CreateRecord
+{
+    protected static string $resource = ProductionItemResource::class;
+}

--- a/app/Filament/Resources/ProductionItemResource/Pages/EditProductionItem.php
+++ b/app/Filament/Resources/ProductionItemResource/Pages/EditProductionItem.php
@@ -1,0 +1,13 @@
+<?php // app/Filament/Resources/ProductionItemResource/Pages/EditProductionItem.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ProductionItemResource\Pages;
+
+use App\Filament\Resources\ProductionItemResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditProductionItem extends EditRecord
+{
+    protected static string $resource = ProductionItemResource::class;
+}

--- a/app/Filament/Resources/ProductionItemResource/Pages/ListProductionItems.php
+++ b/app/Filament/Resources/ProductionItemResource/Pages/ListProductionItems.php
@@ -1,0 +1,13 @@
+<?php // app/Filament/Resources/ProductionItemResource/Pages/ListProductionItems.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ProductionItemResource\Pages;
+
+use App\Filament\Resources\ProductionItemResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListProductionItems extends ListRecords
+{
+    protected static string $resource = ProductionItemResource::class;
+}

--- a/app/Models/ProductionItem.php
+++ b/app/Models/ProductionItem.php
@@ -1,0 +1,33 @@
+<?php // app/Models/ProductionItem.php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\States\ProductionItem\ProductionItemState;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelStates\HasStates;
+
+class ProductionItem extends Model
+{
+    use HasStates;
+
+    protected $fillable = [
+        'name',
+        'part_number',
+        'status',
+    ];
+
+    protected $casts = [
+        'status' => ProductionItemState::class,
+    ];
+
+    public string $displayStatus {
+        get => $this->status->label();
+    }
+
+    public function nextStatus(): ?string
+    {
+        return $this->status->next();
+    }
+}

--- a/app/States/ProductionItem/Cut.php
+++ b/app/States/ProductionItem/Cut.php
@@ -1,0 +1,13 @@
+<?php // app/States/ProductionItem/Cut.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+class Cut extends ProductionItemState
+{
+    public function label(): string
+    {
+        return 'Cut';
+    }
+}

--- a/app/States/ProductionItem/Inspected.php
+++ b/app/States/ProductionItem/Inspected.php
@@ -1,0 +1,13 @@
+<?php // app/States/ProductionItem/Inspected.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+class Inspected extends ProductionItemState
+{
+    public function label(): string
+    {
+        return 'Inspected';
+    }
+}

--- a/app/States/ProductionItem/ProductionItemState.php
+++ b/app/States/ProductionItem/ProductionItemState.php
@@ -1,0 +1,34 @@
+<?php // app/States/ProductionItem/ProductionItemState.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class ProductionItemState extends State
+{
+    abstract public function label(): string;
+
+    public function next(): ?string
+    {
+        return match (static::class) {
+            Queued::class => Cut::class,
+            Cut::class => Welded::class,
+            Welded::class => Inspected::class,
+            Inspected::class => Shipped::class,
+            default => null,
+        };
+    }
+
+    public static function config(): StateConfig
+    {
+        return StateConfig::make()
+            ->default(Queued::class)
+            ->allowTransition(Queued::class, Cut::class)
+            ->allowTransition(Cut::class, Welded::class)
+            ->allowTransition(Welded::class, Inspected::class)
+            ->allowTransition(Inspected::class, Shipped::class);
+    }
+}

--- a/app/States/ProductionItem/Queued.php
+++ b/app/States/ProductionItem/Queued.php
@@ -1,0 +1,13 @@
+<?php // app/States/ProductionItem/Queued.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+class Queued extends ProductionItemState
+{
+    public function label(): string
+    {
+        return 'Queued';
+    }
+}

--- a/app/States/ProductionItem/Shipped.php
+++ b/app/States/ProductionItem/Shipped.php
@@ -1,0 +1,13 @@
+<?php // app/States/ProductionItem/Shipped.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+class Shipped extends ProductionItemState
+{
+    public function label(): string
+    {
+        return 'Shipped';
+    }
+}

--- a/app/States/ProductionItem/Welded.php
+++ b/app/States/ProductionItem/Welded.php
@@ -1,0 +1,13 @@
+<?php // app/States/ProductionItem/Welded.php
+
+declare(strict_types=1);
+
+namespace App\States\ProductionItem;
+
+class Welded extends ProductionItemState
+{
+    public function label(): string
+    {
+        return 'Welded';
+    }
+}

--- a/database/migrations/2026_01_07_000000_create_production_items_table.php
+++ b/database/migrations/2026_01_07_000000_create_production_items_table.php
@@ -1,0 +1,26 @@
+<?php // database/migrations/2026_01_07_000000_create_production_items_table.php
+
+declare(strict_types=1);
+
+use App\States\ProductionItem\Queued;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('production_items', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('part_number');
+            $table->string('status')->default(Queued::class);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('production_items');
+    }
+};


### PR DESCRIPTION
### Motivation

- Implement a Fabrication workflow for a `ProductionItem` model using Spatie model states to represent lifecycle stages.  
- Ensure the status follows a linear path and cannot jump from `Queued` to `Shipped`.  
- Provide an admin-side control to advance status directly from the Filament table for faster operator workflow.  

### Description

- Add migration `2026_01_07_000000_create_production_items_table.php` that creates the `production_items` table with `name`, `part_number`, and `status` defaulting to `Queued::class`.  
- Add `app/Models/ProductionItem.php` using `HasStates`, casting `status` to `ProductionItemState::class`, a PHP 8.4 property-hook `displayStatus`, and a helper `nextStatus()` to determine the next allowed state.  
- Add `app/States/ProductionItem/ProductionItemState.php` plus concrete classes `Queued`, `Cut`, `Welded`, `Inspected`, and `Shipped` with a `next()` matcher and `config()` that allows only the linear transitions.  
- Add `app/Filament/Resources/ProductionItemResource.php` and page classes with a table `Advance Status` action that disables when `nextStatus()` is `null`, calls `transitionTo()` inside a try/catch, saves the model, and shows success/warning/error notifications.  

### Testing

- No automated tests were executed as part of this change.  
- No `phpunit` or other CI jobs were run locally during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db1731bf8832484de15c0efedf49f)