### PR TITLE
Add local TLS support for nginx (certs, nginx.conf, docker-compose, docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+# When using TLS locally (see docker/certs/README.md), use:
+# APP_URL=https://localhost
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,11 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - .:/var/www
       - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./docker/certs:/etc/nginx/certs:ro
     networks:
       - steelflow
     depends_on:
@@ -116,4 +118,3 @@ volumes:
     driver: local
   steelflow-meilisearch:
     driver: local
-

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -1,0 +1,36 @@
+# Local TLS Certificates
+
+This directory holds development TLS certificates for the Nginx container.
+
+## Option A: mkcert (recommended)
+
+1. Install `mkcert` for your OS.
+2. Create and trust a local root CA:
+
+```bash
+mkcert -install
+```
+
+3. Generate a certificate for your dev host (adjust the hostnames if needed):
+
+```bash
+mkcert -cert-file localhost.pem -key-file localhost-key.pem localhost 127.0.0.1 ::1
+```
+
+## Option B: OpenSSL (self-signed)
+
+Generate a one-year self-signed certificate:
+
+```bash
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -keyout localhost-key.pem \
+  -out localhost.pem \
+  -days 365 \
+  -subj "/CN=localhost"
+```
+
+## Notes
+
+- The Nginx config expects `localhost.pem` and `localhost-key.pem` in this folder.
+- Update `.env` and set `APP_URL=https://<host>` when enabling TLS locally.
+- If you change filenames, update `docker/nginx.conf` accordingly.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,6 +4,10 @@ server {
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     root /var/www/public;
+
+    # Optional: redirect HTTP to HTTPS for local testing.
+    # return 301 https://$host$request_uri;
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
@@ -13,7 +17,49 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_X_FORWARDED_HOST $host;
+        fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_SSL $https;
+        fastcgi_param HTTPS $https;
     }
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}
+
+server {
+    listen 443 ssl;
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/public;
+
+    ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_X_FORWARDED_HOST $host;
+        fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_SSL $https;
+        fastcgi_param HTTPS $https;
+    }
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
         gzip_static on;

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -177,6 +177,16 @@ SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
 ```
 
+When enabling TLS locally, set `APP_URL` to the HTTPS host, for example:
+
+```bash
+APP_URL=https://localhost
+```
+
+### Local TLS (Optional)
+
+Generate development certificates in `docker/certs/` (see `docker/certs/README.md`), then expose port `443` and update `APP_URL` to `https://<host>` in your `.env`.
+
 ### Azure OAuth (Optional)
 
 For Microsoft 365 authentication, configure:


### PR DESCRIPTION
### Motivation

- Enable local HTTPS for development and testing by providing a simple way to generate and mount dev TLS certificates in the Nginx container.  
- Ensure the application receives the original request scheme/host via forwarded headers so URL generation and OAuth/callback flows work correctly behind Nginx.  
- Make it easy to opt into HTTP→HTTPS redirects for local verification and testing.  
- Update environment examples and docs so developers know to set `APP_URL` to HTTPS when TLS is enabled.

### Description

- Added `docker/certs/README.md` with instructions for generating dev certificates using `mkcert` (recommended) and `openssl`, and noted expected filenames (`localhost.pem` / `localhost-key.pem`).  
- Updated `docker/nginx.conf` to add a `server` block listening on `443 ssl` with `ssl_certificate`/`ssl_certificate_key`, TLS settings, forwarded `X-Forwarded-*` headers, and an optional HTTP→HTTPS redirect.  
- Modified `docker-compose.yml` to expose `443:443` and mount `./docker/certs` into the Nginx container at `/etc/nginx/certs` as read-only.  
- Updated `.env.example` and `docs/INSTALLATION.md` to show `APP_URL=https://localhost` guidance when local TLS is enabled.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8b9200f883248033670ac4c52a85)