### PR TITLE
Add TrustProxies middleware to honor X-Forwarded-* headers

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,24 @@
+<?php
+// app/Http/Middleware/TrustProxies.php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
+use Illuminate\Http\Request;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application.
+     *
+     * @var array<int, string>|string|null
+     */
+    protected $proxies = '*';
+
+    /**
+     * The headers that should be used to detect proxies.
+     *
+     * @var int
+     */
+    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->prepend(\App\Http\Middleware\TrustProxies::class);
+
         $middleware->web(
             prepend: [
                 \App\Http\Middleware\RequestContextMiddleware::class,


### PR DESCRIPTION
### Motivation
- Ensure the framework trusts the reverse proxy and correctly interprets `X-Forwarded-*` headers for client IP and scheme.
- Make URL generation HTTPS-aware when a fronting proxy sets `X-Forwarded-Proto: https` so generated links and redirects use the correct scheme.
- Run forwarded-header handling early so downstream middleware and routing see the original client values.

### Description
- Add `app/Http/Middleware/TrustProxies.php` which extends `Illuminate\Http\Middleware\TrustProxies` with `protected $proxies = '*'` and `protected $headers = Request::HEADER_X_FORWARDED_ALL` to trust proxies and honor all forwarded headers.
- Register the middleware early by prepending `\App\Http\Middleware\TrustProxies::class` in `bootstrap/app.php` so it runs before other global middleware.
- The change targets Laravel 11-style bootstrap configuration and makes scheme/IP detection consistent behind reverse proxies.

### Testing
- No automated tests were executed as part of this change.
- Recommend running the project test suite and end-to-end requests with `X-Forwarded-Proto: https` to validate HTTPS-aware URL generation in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8b93716c8324b1ebfec9c38ca734)