### PR TITLE
Add filtered inventory status counts summary

### DIFF
--- a/app/Http/Controllers/InventoryController.php
+++ b/app/Http/Controllers/InventoryController.php
@@ -71,6 +71,12 @@ class InventoryController extends Controller
         $sortColumn = $sortableColumns[$sortBy] ?? 'created_at';
         $query->orderBy($sortColumn, $sortDirection);
 
+        $statusCounts = (clone $query)
+            ->selectRaw('status, COUNT(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status')
+            ->toArray();
+
         $stockItems = $query->paginate(20)->withQueryString();
 
         return Inertia::render('Inventory/Index', [
@@ -79,6 +85,7 @@ class InventoryController extends Controller
             'statuses' => $this->getStatuses(),
             'locations' => $this->getStockAreas(),
             'grades' => $this->getUniqueGrades(),
+            'statusCounts' => $statusCounts,
         ]);
     }
 

--- a/resources/js/Pages/Inventory/Index.vue
+++ b/resources/js/Pages/Inventory/Index.vue
@@ -9,6 +9,7 @@ const props = defineProps({
     statuses: Object,
     locations: Object,
     grades: Array,
+    statusCounts: Object,
 });
 
 const search = ref(props.filters?.search || '');
@@ -65,6 +66,14 @@ const getSortIcon = (column) => {
 
 const isSortedBy = (column) => {
     return sortBy.value === column;
+};
+
+const getStatusCount = (status) => {
+    if (!props.statusCounts) {
+        return 0;
+    }
+
+    return props.statusCounts[status] ?? 0;
 };
 </script>
 
@@ -462,7 +471,7 @@ const isSortedBy = (column) => {
           Free Stock
         </div>
         <div class="text-2xl font-bold font-mono text-green-400 mt-2">
-          {{ stockItems.data.filter(i => i.status === 'free').length }}
+          {{ getStatusCount('free') }}
         </div>
       </div>
       <div class="card-industrial bg-steel-900 border-weld-900">
@@ -470,7 +479,7 @@ const isSortedBy = (column) => {
           Assigned
         </div>
         <div class="text-2xl font-bold font-mono text-weld-400 mt-2">
-          {{ stockItems.data.filter(i => i.status === 'assigned').length }}
+          {{ getStatusCount('assigned') }}
         </div>
       </div>
       <div class="card-industrial bg-steel-900 border-steel-700">
@@ -478,7 +487,7 @@ const isSortedBy = (column) => {
           Used
         </div>
         <div class="text-2xl font-bold font-mono text-text-tertiary mt-2">
-          {{ stockItems.data.filter(i => i.status === 'used').length }}
+          {{ getStatusCount('used') }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Ensure the inventory summary cards show accurate counts that respect the current filters rather than only the paginated page data.
- Provide a server-side aggregation so counts remain correct while preserving pagination and sorting.

### Description

- Add a cloned query aggregation in `InventoryController@index` to compute `statusCounts` grouped by `status` and pass it to the Inertia view as `statusCounts`.
- Update `resources/js/Pages/Inventory/Index.vue` to accept a new `statusCounts` prop and add `getStatusCount()` to read counts for each summary card.
- Replace client-side per-page counting in the summary cards with calls to `getStatusCount()` so totals reflect the filtered dataset.

### Testing

- No automated tests were executed for this change.
- The change was committed and files updated: `app/Http/Controllers/InventoryController.php` and `resources/js/Pages/Inventory/Index.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb77241108324b41dd77a5d1ad7b4)