### PR TITLE
Add Reports module (overview, inventory & project BOM pages)

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1,4 +1,5 @@
 <?php
+// app/Http/Controllers/ReportController.php
 
 namespace App\Http\Controllers;
 
@@ -14,9 +15,7 @@ class ReportController extends Controller
 
     public function index()
     {
-        return Inertia::render('Reports/Index', [
-            'metrics' => $this->reportingService->getDashboardMetrics(),
-        ]);
+        return Inertia::render('Reports/Index', $this->reportingService->getReportsOverview());
     }
 
     public function projectBom(Project $project)

--- a/app/Services/ReportingService.php
+++ b/app/Services/ReportingService.php
@@ -1,4 +1,5 @@
 <?php
+// app/Services/ReportingService.php
 
 namespace App\Services;
 
@@ -9,6 +10,21 @@ use Illuminate\Support\Facades\DB;
 
 class ReportingService
 {
+    /**
+     * Get report module overview data.
+     */
+    public function getReportsOverview(): array
+    {
+        return [
+            'metrics' => $this->getDashboardMetrics(),
+            'inventorySnapshot' => $this->getInventoryReport(),
+            'projects' => Project::with('customer')
+                ->orderByDesc('updated_at')
+                ->limit(6)
+                ->get(),
+        ];
+    }
+
     /**
      * Get summary metrics for the main dashboard.
      */

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -8,6 +8,7 @@ defineProps({
 
 const navigation = [
     { name: 'Dashboard', href: '/dashboard', icon: 'chart' },
+    { name: 'Reports', href: '/reports', icon: 'chart' },
     { name: 'Projects', href: '/projects', icon: 'folder' },
     { name: 'Drawings', href: '/drawings', icon: 'document' },
     { name: 'Customers', href: '/customers', icon: 'users' },

--- a/resources/js/Pages/Reports/Index.vue
+++ b/resources/js/Pages/Reports/Index.vue
@@ -1,66 +1,269 @@
+<!-- resources/js/Pages/Reports/Index.vue -->
 <script setup>
+import { Link } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 
-defineProps({
+const props = defineProps({
     metrics: Object,
+    inventorySnapshot: Object,
+    projects: Array,
 });
+
+const formatCurrency = (value) => {
+    if (!value && value !== 0) return '£0';
+    return new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        maximumFractionDigits: 0,
+    }).format(value);
+};
+
+const inventorySummary = () => props.inventorySnapshot ?? { total_items: 0, valuation: 0, by_type: [] };
 </script>
 
 <template>
-  <AppLayout title="Dashboard">
+  <AppLayout title="Reports">
     <template #header>
-      <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-        Dashboard Overview
-      </h2>
+      <div class="flex flex-col gap-2">
+        <h2 class="font-semibold text-2xl text-white leading-tight">
+          Reports Command Centre
+        </h2>
+        <p class="text-text-secondary font-mono text-sm">
+          A clean overview of operational performance, inventory health, and project BOM detail.
+        </p>
+      </div>
     </template>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6">
-        <div class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+    <!-- Key metrics overview -->
+    <section class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
           Active Projects
         </div>
-        <div class="mt-1 text-3xl font-semibold text-gray-900 dark:text-gray-100">
+        <div class="mt-4 text-3xl font-bold text-white">
           {{ metrics?.active_projects ?? 0 }}
         </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Live jobs across production and active stages.
+        </p>
       </div>
 
-      <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6">
-        <div class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-          Total Weight (Lbs)
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+          Total Weight
         </div>
-        <div class="mt-1 text-3xl font-semibold text-gray-900 dark:text-gray-100">
-          {{ metrics?.total_weight_lbs?.toLocaleString() ?? '0' }}
+        <div class="mt-4 text-3xl font-bold text-white">
+          {{ metrics?.total_weight_lbs?.toLocaleString() ?? '0' }} lbs
         </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Sum of assembly weights across the yard.
+        </p>
       </div>
 
-      <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6">
-        <div class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
           Production Progress
         </div>
-        <div class="mt-1 text-3xl font-semibold text-gray-900 dark:text-gray-100">
+        <div class="mt-4 text-3xl font-bold text-white">
           {{ metrics?.production_completion_percentage ?? 0 }}%
         </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Parts cleared as complete versus total scope.
+        </p>
       </div>
 
-      <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6">
-        <div class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
           Ready to Ship
         </div>
-        <div class="mt-1 text-3xl font-semibold text-gray-900 dark:text-gray-100">
+        <div class="mt-4 text-3xl font-bold text-white">
           {{ metrics?.ready_to_ship_pieces ?? 0 }}
         </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Completed assemblies awaiting logistics.
+        </p>
       </div>
-    </div>
+    </section>
 
-    <div class="mt-8 bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg">
-      <div class="p-6 border-b border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-          Recent Activity
-        </h3>
-        <div class="mt-4 text-gray-600 dark:text-gray-400">
-          Welcome to SteelFlow MRP. Start by importing your first KISS file or viewing active projects.
+    <!-- Available reports -->
+    <section class="mt-10 grid grid-cols-1 xl:grid-cols-3 gap-6">
+      <div class="xl:col-span-2 card-industrial">
+        <div class="flex items-center justify-between mb-6">
+          <div>
+            <h3 class="text-lg font-semibold text-white">
+              Inventory Valuation Snapshot
+            </h3>
+            <p class="text-sm text-text-secondary">
+              A rapid read on current stock value and material mix.
+            </p>
+          </div>
+          <Link
+            href="/reports/inventory"
+            class="btn-secondary"
+          >
+            View Inventory Report
+          </Link>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div class="bg-steel-900/60 border border-steel-700 rounded-sm p-5">
+            <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+              Usable Stock Items
+            </div>
+            <div class="mt-3 text-2xl font-semibold text-white">
+              {{ inventorySummary().total_items ?? 0 }}
+            </div>
+            <p class="mt-2 text-sm text-text-secondary">
+              Items not yet marked as used.
+            </p>
+          </div>
+          <div class="bg-steel-900/60 border border-steel-700 rounded-sm p-5">
+            <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+              Estimated Valuation
+            </div>
+            <div class="mt-3 text-2xl font-semibold text-white">
+              {{ formatCurrency(inventorySummary().valuation ?? 0) }}
+            </div>
+            <p class="mt-2 text-sm text-text-secondary">
+              Based on length × cost per unit.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <h4 class="text-sm uppercase tracking-wider text-text-tertiary font-semibold">
+            Top Material Types
+          </h4>
+          <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div
+              v-for="type in (inventorySummary().by_type ?? []).slice(0, 3)"
+              :key="type.type"
+              class="bg-steel-900/40 border border-steel-700 rounded-sm p-4"
+            >
+              <div class="text-sm font-semibold text-white">
+                {{ type.type || 'Unknown' }}
+              </div>
+              <div class="mt-2 text-xs text-text-secondary">
+                {{ type.count }} items • {{ type.total_length ?? 0 }}" total length
+              </div>
+            </div>
+            <div
+              v-if="(inventorySummary().by_type ?? []).length === 0"
+              class="bg-steel-900/40 border border-steel-700 rounded-sm p-4 text-sm text-text-secondary"
+            >
+              No inventory data yet. Add stock to build the valuation report.
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+
+      <div class="card-industrial">
+        <div class="mb-6">
+          <h3 class="text-lg font-semibold text-white">
+            Report Library
+          </h3>
+          <p class="text-sm text-text-secondary">
+            Quick access to frequently used reporting views.
+          </p>
+        </div>
+
+        <div class="space-y-4">
+          <Link
+            href="/reports/inventory"
+            class="block border border-steel-700 rounded-sm p-4 hover:border-forge-500 transition-colors"
+          >
+            <div class="text-sm font-semibold text-white">Inventory Snapshot</div>
+            <div class="mt-1 text-xs text-text-secondary">
+              Stock valuation, usage, and type totals.
+            </div>
+          </Link>
+
+          <Link
+            href="/projects"
+            class="block border border-steel-700 rounded-sm p-4 hover:border-forge-500 transition-colors"
+          >
+            <div class="text-sm font-semibold text-white">Project BOMs</div>
+            <div class="mt-1 text-xs text-text-secondary">
+              Select a project to open its Bill of Materials report.
+            </div>
+          </Link>
+
+          <div class="border border-steel-700 rounded-sm p-4 text-xs text-text-secondary">
+            More reports coming soon. Suggestions welcome.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Recent projects for BOM access -->
+    <section class="mt-10 card-industrial">
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h3 class="text-lg font-semibold text-white">
+            Recent Project BOMs
+          </h3>
+          <p class="text-sm text-text-secondary">
+            Jump straight into the most recently updated jobs.
+          </p>
+        </div>
+        <Link
+          href="/projects"
+          class="btn-secondary"
+        >
+          View All Projects
+        </Link>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-xs uppercase tracking-wider text-text-tertiary">
+            <tr class="border-b border-steel-700">
+              <th class="py-3 text-left">Job</th>
+              <th class="py-3 text-left">Customer</th>
+              <th class="py-3 text-left">Status</th>
+              <th class="py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="project in projects ?? []"
+              :key="project.id"
+              class="border-b border-steel-800/80 text-text-secondary"
+            >
+              <td class="py-3 text-white">
+                <div class="font-semibold">
+                  {{ project.name ?? 'Untitled Project' }}
+                </div>
+                <div class="text-xs text-text-tertiary">
+                  {{ project.job_number ?? 'No job number' }}
+                </div>
+              </td>
+              <td class="py-3">
+                {{ project.customer?.name ?? 'No customer' }}
+              </td>
+              <td class="py-3 capitalize">
+                {{ project.status ?? 'unknown' }}
+              </td>
+              <td class="py-3 text-right">
+                <Link
+                  :href="`/reports/project/${project.id}/bom`"
+                  class="btn-primary"
+                >
+                  View BOM
+                </Link>
+              </td>
+            </tr>
+            <tr v-if="(projects ?? []).length === 0">
+              <td
+                colspan="4"
+                class="py-6 text-center text-sm text-text-secondary"
+              >
+                No projects yet. Add a project to unlock BOM reporting.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </AppLayout>
 </template>

--- a/resources/js/Pages/Reports/Inventory.vue
+++ b/resources/js/Pages/Reports/Inventory.vue
@@ -1,0 +1,133 @@
+<!-- resources/js/Pages/Reports/Inventory.vue -->
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+const props = defineProps({
+    total_items: Number,
+    valuation: Number,
+    by_type: Array,
+});
+
+const formatCurrency = (value) => {
+    if (!value && value !== 0) return '£0';
+    return new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        maximumFractionDigits: 0,
+    }).format(value);
+};
+</script>
+
+<template>
+  <AppLayout title="Inventory Report">
+    <template #header>
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <div>
+            <h2 class="font-semibold text-2xl text-white leading-tight">
+              Inventory Report
+            </h2>
+            <p class="text-text-secondary font-mono text-sm">
+              A tidy summary of available stock and valuation totals.
+            </p>
+          </div>
+          <Link
+            href="/reports"
+            class="btn-secondary"
+          >
+            Back to Reports
+          </Link>
+        </div>
+      </div>
+    </template>
+
+    <!-- Summary cards -->
+    <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+          Usable Stock Items
+        </div>
+        <div class="mt-4 text-3xl font-bold text-white">
+          {{ total_items ?? 0 }}
+        </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Items not marked as used.
+        </p>
+      </div>
+
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+          Estimated Valuation
+        </div>
+        <div class="mt-4 text-3xl font-bold text-white">
+          {{ formatCurrency(valuation ?? 0) }}
+        </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Based on length multiplied by unit cost.
+        </p>
+      </div>
+
+      <div class="card-industrial">
+        <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold">
+          Material Types
+        </div>
+        <div class="mt-4 text-3xl font-bold text-white">
+          {{ (by_type ?? []).length }}
+        </div>
+        <p class="mt-2 text-sm text-text-secondary">
+          Distinct types with available stock.
+        </p>
+      </div>
+    </section>
+
+    <!-- Breakdown table -->
+    <section class="mt-10 card-industrial">
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-white">
+          Inventory Breakdown by Type
+        </h3>
+        <p class="text-sm text-text-secondary">
+          Counts and total lengths by material type.
+        </p>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-xs uppercase tracking-wider text-text-tertiary">
+            <tr class="border-b border-steel-700">
+              <th class="py-3 text-left">Type</th>
+              <th class="py-3 text-right">Item Count</th>
+              <th class="py-3 text-right">Total Length</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="type in by_type ?? []"
+              :key="type.type"
+              class="border-b border-steel-800/80 text-text-secondary"
+            >
+              <td class="py-3 text-white">
+                {{ type.type || 'Unknown' }}
+              </td>
+              <td class="py-3 text-right">
+                {{ type.count ?? 0 }}
+              </td>
+              <td class="py-3 text-right">
+                {{ type.total_length ?? 0 }}"
+              </td>
+            </tr>
+            <tr v-if="(by_type ?? []).length === 0">
+              <td
+                colspan="3"
+                class="py-6 text-center text-sm text-text-secondary"
+              >
+                No inventory data yet. Add stock items to populate this report.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </AppLayout>
+</template>

--- a/resources/js/Pages/Reports/ProjectBom.vue
+++ b/resources/js/Pages/Reports/ProjectBom.vue
@@ -1,0 +1,123 @@
+<!-- resources/js/Pages/Reports/ProjectBom.vue -->
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+const props = defineProps({
+    project: Object,
+    assemblies: Array,
+});
+
+const formatWeight = (value) => {
+    if (value === null || value === undefined) return '-';
+    return `${Number(value).toFixed(2)} lbs`;
+};
+</script>
+
+<template>
+  <AppLayout title="Project BOM Report">
+    <template #header>
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <div>
+            <h2 class="font-semibold text-2xl text-white leading-tight">
+              BOM Report: {{ project?.name ?? 'Project' }}
+            </h2>
+            <p class="text-text-secondary font-mono text-sm">
+              Job {{ project?.job_number ?? 'N/A' }} • {{ project?.customer?.name ?? 'No customer' }}
+            </p>
+          </div>
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              class="btn-secondary"
+              @click="window.print()"
+            >
+              Print BOM
+            </button>
+            <Link
+              href="/reports"
+              class="btn-secondary"
+            >
+              Back to Reports
+            </Link>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Assembly breakdown -->
+    <section class="space-y-8">
+      <div
+        v-for="assembly in assemblies ?? []"
+        :key="assembly.id"
+        class="card-industrial"
+      >
+        <div class="mb-4">
+          <h3 class="text-lg font-semibold text-white">
+            Assembly: {{ assembly.mark ?? 'Mark' }} — {{ assembly.description ?? 'No description' }}
+          </h3>
+          <p class="text-sm text-text-secondary">
+            Quantity: {{ assembly.quantity ?? 0 }}
+          </p>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead class="text-xs uppercase tracking-wider text-text-tertiary">
+              <tr class="border-b border-steel-700">
+                <th class="py-3 text-left">Part Mark</th>
+                <th class="py-3 text-right">Qty</th>
+                <th class="py-3 text-left">Material</th>
+                <th class="py-3 text-left">Size</th>
+                <th class="py-3 text-right">Length</th>
+                <th class="py-3 text-right">Weight (ea)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="part in assembly.parts ?? []"
+                :key="part.id"
+                class="border-b border-steel-800/80 text-text-secondary"
+              >
+                <td class="py-3 text-white">
+                  {{ part.part_mark ?? 'N/A' }}
+                </td>
+                <td class="py-3 text-right">
+                  {{ part.quantity ?? 0 }}
+                </td>
+                <td class="py-3">
+                  {{ part.grade ?? part.material?.grade ?? 'N/A' }}
+                </td>
+                <td class="py-3">
+                  {{ part.size_imperial ?? part.material?.size_imperial ?? 'N/A' }}
+                </td>
+                <td class="py-3 text-right">
+                  {{ part.length ?? '-' }}
+                </td>
+                <td class="py-3 text-right">
+                  {{ formatWeight(part.weight_each_lbs) }}
+                </td>
+              </tr>
+              <tr v-if="(assembly.parts ?? []).length === 0">
+                <td
+                  colspan="6"
+                  class="py-6 text-center text-sm text-text-secondary"
+                >
+                  No parts recorded for this assembly yet.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div
+        v-if="(assemblies ?? []).length === 0"
+        class="card-industrial text-sm text-text-secondary"
+      >
+        No assemblies found for this project. Upload a KISS file to generate the BOM report.
+      </div>
+    </section>
+  </AppLayout>
+</template>


### PR DESCRIPTION
### Motivation
- Provide a central Reports hub that surfaces operational metrics, an inventory snapshot and quick access to project BOMs.
- Offer dedicated report pages for inventory valuation and per-project bill-of-materials to improve visibility for production and logistics.
- Surface a short list of recent projects for fast BOM access from the reports landing page.

### Description
- Added `ReportingService::getReportsOverview()` to assemble `metrics`, `inventorySnapshot` and recent `projects` and updated `ReportController::index()` to return that dataset (files: `app/Services/ReportingService.php`, `app/Http/Controllers/ReportController.php`).
- Implemented a Reports landing page at `resources/js/Pages/Reports/Index.vue` that shows key metrics, inventory snapshot, a report library and recent projects with links to BOMs.
- Created `resources/js/Pages/Reports/Inventory.vue` and `resources/js/Pages/Reports/ProjectBom.vue` for the inventory valuation report and printable project BOM respectively.
- Added a `Reports` entry to the main navigation in `resources/js/Layouts/AppLayout.vue` for discoverability.

### Testing
- Attempted to run the application with `php artisan serve --host 0.0.0.0 --port 8000`, which failed because Composer dependencies are not installed and `vendor/autoload.php` was missing (failure).
- No automated unit or integration tests were executed as part of this rollout (not present/ran).
- Files were linted visually and committed successfully into the repository (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb8e7785c8324970cd220db4f9ee4)