### PR TITLE
Fix inventory controller base import

### DIFF
--- a/Modules/Inventory/app/Http/Controllers/InventoryController.php
+++ b/Modules/Inventory/app/Http/Controllers/InventoryController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Inventory\Http\Controllers;
 
+use App\Http\Controllers\Controller;
 use Modules\Inventory\Http\Requests\StoreStockItemRequest;
 use Modules\Inventory\Http\Requests\UpdateStockItemRequest;
 use Modules\Inventory\Models\Grade;


### PR DESCRIPTION
### Motivation
- The `InventoryController` extended `Controller` but did not import the base class, causing a missing class resolution error at runtime.
- Importing the framework base controller ensures the module's controller resolves correctly when loaded.

### Description
- Add the import statement `use App\Http\Controllers\Controller;` to `Modules/Inventory/app/Http/Controllers/InventoryController.php` so the class reference is resolved.
- No other logic or behavior in `InventoryController` was changed.

### Testing
- No automated tests were executed for this change.
- The repository change was committed after applying the import and the file was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee0b4cb9883249c16229040c0ca2c)