### PR TITLE
Add Core module scaffold and status pipeline helpers

### DIFF
--- a/Modules/Core/app/Providers/CoreServiceProvider.php
+++ b/Modules/Core/app/Providers/CoreServiceProvider.php
@@ -1,0 +1,82 @@
+<?php
+// Modules/Core/app/Providers/CoreServiceProvider.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Nwidart\Modules\Traits\PathNamespace;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class CoreServiceProvider extends ServiceProvider
+{
+    use PathNamespace;
+
+    protected string $name = 'Core';
+
+    protected string $nameLower = 'core';
+
+    /**
+     * Boot the application events.
+     */
+    public function boot(): void
+    {
+        $this->registerConfig();
+        $this->loadMigrationsFrom(module_path($this->name, 'database/migrations'));
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register config.
+     */
+    protected function registerConfig(): void
+    {
+        $configPath = module_path($this->name, config('modules.paths.generator.config.path'));
+
+        if (! is_dir($configPath)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $config = str_replace($configPath.DIRECTORY_SEPARATOR, '', $file->getPathname());
+                $configKey = str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $config);
+                $segments = explode('.', $this->nameLower.'.'.$configKey);
+
+                $normalized = [];
+                foreach ($segments as $segment) {
+                    if (end($normalized) !== $segment) {
+                        $normalized[] = $segment;
+                    }
+                }
+
+                $key = ($config === 'config.php') ? $this->nameLower : implode('.', $normalized);
+
+                $this->publishes([$file->getPathname() => config_path($config)], 'config');
+                $this->mergeConfigFromPath($file->getPathname(), $key);
+            }
+        }
+    }
+
+    /**
+     * Merge config from the given path recursively.
+     */
+    protected function mergeConfigFromPath(string $path, string $key): void
+    {
+        $existing = config($key, []);
+        $moduleConfig = require $path;
+
+        config([$key => array_replace_recursive($existing, $moduleConfig)]);
+    }
+}

--- a/Modules/Core/app/Providers/RouteServiceProvider.php
+++ b/Modules/Core/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+// Modules/Core/app/Providers/RouteServiceProvider.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected string $name = 'Core';
+
+    /**
+     * Called before routes are registered.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     */
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')->group(module_path($this->name, '/routes/web.php'));
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     */
+    protected function mapApiRoutes(): void
+    {
+        Route::middleware('api')->prefix('api')->name('api.')->group(module_path($this->name, '/routes/api.php'));
+    }
+}

--- a/Modules/Core/app/Status/StatusDefinition.php
+++ b/Modules/Core/app/Status/StatusDefinition.php
@@ -1,0 +1,51 @@
+<?php
+// Modules/Core/app/Status/StatusDefinition.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Status;
+
+final class StatusDefinition
+{
+    /**
+     * @param array<string, mixed> $meta
+     */
+    public function __construct(
+        public readonly string $key,
+        public readonly string $label,
+        public readonly ?string $color = null,
+        public readonly ?string $next = null,
+        public readonly array $meta = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    public static function fromArray(string $key, array $definition): self
+    {
+        $label = $definition['label'] ?? ucfirst(str_replace('_', ' ', $key));
+
+        return new self(
+            $key,
+            $label,
+            $definition['color'] ?? null,
+            $definition['next'] ?? null,
+            $definition['meta'] ?? [],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'key' => $this->key,
+            'label' => $this->label,
+            'color' => $this->color,
+            'next' => $this->next,
+            'meta' => $this->meta,
+        ];
+    }
+}

--- a/Modules/Core/app/Status/StatusPipeline.php
+++ b/Modules/Core/app/Status/StatusPipeline.php
@@ -1,0 +1,90 @@
+<?php
+// Modules/Core/app/Status/StatusPipeline.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Status;
+
+use Illuminate\Support\Arr;
+
+final class StatusPipeline
+{
+    /**
+     * @var array<string, StatusDefinition>
+     */
+    private array $definitions;
+
+    /**
+     * @param array<string, StatusDefinition> $definitions
+     */
+    public function __construct(
+        public readonly string $name,
+        array $definitions,
+    ) {
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $definitions
+     */
+    public static function fromConfig(string $name, array $definitions): self
+    {
+        $mapped = [];
+
+        foreach ($definitions as $key => $definition) {
+            $mapped[$key] = StatusDefinition::fromArray($key, $definition);
+        }
+
+        return new self($name, $mapped);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->definitions);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function labels(): array
+    {
+        return Arr::map($this->definitions, static fn (StatusDefinition $definition) => $definition->label);
+    }
+
+    public function has(string $status): bool
+    {
+        return array_key_exists($status, $this->definitions);
+    }
+
+    public function definition(string $status): ?StatusDefinition
+    {
+        return $this->definitions[$status] ?? null;
+    }
+
+    public function next(string $status): ?string
+    {
+        return $this->definitions[$status]->next ?? null;
+    }
+
+    public function label(string $status): string
+    {
+        return $this->definitions[$status]->label ?? ucfirst(str_replace('_', ' ', $status));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        $output = [];
+
+        foreach ($this->definitions as $key => $definition) {
+            $output[$key] = $definition->toArray();
+        }
+
+        return $output;
+    }
+}

--- a/Modules/Core/app/Status/StatusRegistry.php
+++ b/Modules/Core/app/Status/StatusRegistry.php
@@ -1,0 +1,39 @@
+<?php
+// Modules/Core/app/Status/StatusRegistry.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Status;
+
+use InvalidArgumentException;
+
+final class StatusRegistry
+{
+    /**
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    public static function all(): array
+    {
+        $pipelines = config('core.status_pipelines', []);
+
+        return is_array($pipelines) ? $pipelines : [];
+    }
+
+    public static function has(string $name): bool
+    {
+        return array_key_exists($name, self::all());
+    }
+
+    public static function pipeline(string $name): StatusPipeline
+    {
+        $pipelines = self::all();
+
+        if (! array_key_exists($name, $pipelines)) {
+            throw new InvalidArgumentException("Status pipeline '{$name}' is not registered.");
+        }
+
+        $definition = $pipelines[$name];
+
+        return StatusPipeline::fromConfig($name, $definition);
+    }
+}

--- a/Modules/Core/app/Traits/HasStatusPipeline.php
+++ b/Modules/Core/app/Traits/HasStatusPipeline.php
@@ -1,0 +1,52 @@
+<?php
+// Modules/Core/app/Traits/HasStatusPipeline.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Traits;
+
+use Modules\Core\Status\StatusPipeline;
+use Modules\Core\Status\StatusRegistry;
+
+trait HasStatusPipeline
+{
+    abstract protected function statusPipelineName(): string;
+
+    public function statusPipeline(): StatusPipeline
+    {
+        return StatusRegistry::pipeline($this->statusPipelineName());
+    }
+
+    public function statusLabel(?string $status = null): string
+    {
+        $current = $status ?? $this->status ?? '';
+
+        if ($current === '') {
+            return '';
+        }
+
+        return $this->statusPipeline()->label($current);
+    }
+
+    public function nextStatus(?string $status = null): ?string
+    {
+        $current = $status ?? $this->status ?? null;
+
+        if ($current === null) {
+            return null;
+        }
+
+        return $this->statusPipeline()->next($current);
+    }
+
+    public function hasValidStatus(?string $status = null): bool
+    {
+        $current = $status ?? $this->status ?? null;
+
+        if ($current === null) {
+            return false;
+        }
+
+        return $this->statusPipeline()->has($current);
+    }
+}

--- a/Modules/Core/config/config.php
+++ b/Modules/Core/config/config.php
@@ -1,0 +1,28 @@
+<?php
+// Modules/Core/config/config.php
+
+declare(strict_types=1);
+
+return [
+    'status_pipelines' => [
+        'project' => [
+            'bid' => ['label' => 'Bid', 'color' => 'gray', 'next' => 'active'],
+            'active' => ['label' => 'Active', 'color' => 'primary', 'next' => 'production'],
+            'production' => ['label' => 'Production', 'color' => 'warning', 'next' => 'shipping'],
+            'shipping' => ['label' => 'Shipping', 'color' => 'info', 'next' => 'complete'],
+            'complete' => ['label' => 'Complete', 'color' => 'success', 'next' => 'archived'],
+            'archived' => ['label' => 'Archived', 'color' => 'secondary'],
+        ],
+        'stock_item' => [
+            'free' => ['label' => 'Free', 'color' => 'success'],
+            'assigned' => ['label' => 'Assigned', 'color' => 'warning'],
+            'committed' => ['label' => 'Committed', 'color' => 'warning'],
+            'used' => ['label' => 'Used', 'color' => 'secondary'],
+            'available' => ['label' => 'Available', 'color' => 'success'],
+            'reserved' => ['label' => 'Reserved', 'color' => 'info'],
+            'checked_out' => ['label' => 'Checked Out', 'color' => 'warning'],
+            'lost' => ['label' => 'Lost', 'color' => 'danger'],
+            'damaged' => ['label' => 'Damaged', 'color' => 'danger'],
+        ],
+    ],
+];

--- a/Modules/Core/module.json
+++ b/Modules/Core/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Core",
+    "alias": "core",
+    "description": "Shared core utilities, conventions, and UI helpers for SteelFlow MRP.",
+    "keywords": ["core", "shared", "helpers"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Core\\Providers\\CoreServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Core/routes/api.php
+++ b/Modules/Core/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+// Modules/Core/routes/api.php
+
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('api')->group(function (): void {
+    // Core module API routes go here.
+});

--- a/Modules/Core/routes/web.php
+++ b/Modules/Core/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+// Modules/Core/routes/web.php
+
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('web')->group(function (): void {
+    // Core module web routes go here.
+});

--- a/codex_TODO.md
+++ b/codex_TODO.md
@@ -7,8 +7,8 @@ This file tracks the actionable TODOs required to deliver the SteelFlow MRP Feat
 ## TODO (Build Order)
 
 ### 1) Core Foundation (Modules + Core/Authz/AuditLog)
-- [ ] Scaffold modular architecture (domain modules) and a shared `Core` module for traits/enums/helpers/UI components.
-- [ ] Define status pipeline conventions and reusable status helpers in `Core`.
+- [x] Scaffold modular architecture (domain modules) and a shared `Core` module for traits/enums/helpers/UI components.
+- [x] Define status pipeline conventions and reusable status helpers in `Core`.
 - [ ] Establish audit-first data conventions (created_by/updated_by + immutable history hooks).
 - [ ] Build `Authz` module: roles, permissions, policy conventions, Filament integration.
 - [ ] Build `AuditLog` module: record timeline, immutable history, per-record audit views.


### PR DESCRIPTION
### Motivation
- Provide a shared `Core` module to centralise common utilities, providers, and route scaffolding for a modular SteelFlow MRP architecture.
- Standardise status handling across domains by introducing configurable status pipelines and reusable helpers to avoid duplicated status logic.
- Fulfil two TODO items by scaffolding the Core foundation and shipping status-convention helpers for further modules to consume.

### Description
- Added a new `Modules/Core` module with `module.json`, placeholder `routes/web.php` and `routes/api.php`, and a `CoreServiceProvider` and `RouteServiceProvider` to register module config and routes.
- Implemented status pipeline primitives: `StatusDefinition`, `StatusPipeline`, and `StatusRegistry` in `Modules/Core/app/Status` to load pipelines from `Modules/Core/config/config.php`.
- Added a reusable trait `HasStatusPipeline` in `Modules/Core/app/Traits` that provides `statusPipeline()`, `statusLabel()`, `nextStatus()`, and `hasValidStatus()` helpers for models.
- Updated `codex_TODO.md` to mark the Core foundation tasks 1 and 2 as complete.

### Testing
- No automated tests were run as part of this change (`phpunit`/`pint` were not executed).
- Files were committed and staged successfully; manual verification of file presence was performed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1443795c8324bb1a072c6a0fef09)