### PR TITLE
Fix ESLint unused props warning in System page

### DIFF
--- a/resources/js/Pages/Admin/System.vue
+++ b/resources/js/Pages/Admin/System.vue
@@ -1,10 +1,6 @@
 <script setup>
-import { router, } from '@inertiajs/vue3';
+import { router } from '@inertiajs/vue3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-
-const props = defineProps({
-    phpInfo: String,
-});
 
 const clearCache = (type = 'all') => {
     router.post(route('admin.system.clear-cache'), { type }, {


### PR DESCRIPTION
### Motivation

- CI linting failed due to an ESLint `no-unused-vars` error in the admin System page caused by an unused `defineProps` declaration.
- The unused prop was unnecessary for the current implementation and blocked the repository lint job.

### Description

- Removed the unused `defineProps` block from `resources/js/Pages/Admin/System.vue` to eliminate the lint warning.
- Simplified the import statement to `import { router } from '@inertiajs/vue3';` by removing the trailing comma.
- Kept the `clearCache` handler and template intact so UI behavior remains unchanged.

### Testing

- Ran `npm run lint` and the linting passed with no errors. 
- No other automated test changes were required for this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696011599b608324b6b02221e0c22ce3)