### PR TITLE
Establish audit field conventions and hooks

### DIFF
--- a/Modules/Core/Events/ModelAuditEvent.php
+++ b/Modules/Core/Events/ModelAuditEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+// Modules/Core/app/Events/ModelAuditEvent.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Events;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelAuditEvent
+{
+    /**
+     * @param  array<string, mixed>  $changes
+     * @param  array<string, mixed>  $original
+     */
+    public function __construct(
+        public readonly Model $model,
+        public readonly string $action,
+        public readonly ?int $actorId,
+        public readonly array $changes,
+        public readonly array $original,
+    ) {
+    }
+}

--- a/Modules/Core/Traits/HasAuditFields.php
+++ b/Modules/Core/Traits/HasAuditFields.php
@@ -1,0 +1,72 @@
+<?php
+
+// Modules/Core/app/Traits/HasAuditFields.php
+
+declare(strict_types=1);
+
+namespace Modules\Core\Traits;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
+use Modules\Core\Events\ModelAuditEvent;
+
+trait HasAuditFields
+{
+    public static function bootHasAuditFields(): void
+    {
+        static::creating(function (Model $model): void {
+            $actorId = Auth::id();
+
+            if ($actorId === null) {
+                return;
+            }
+
+            if ($model->getAttribute('created_by') === null) {
+                $model->setAttribute('created_by', $actorId);
+            }
+
+            if ($model->getAttribute('updated_by') === null) {
+                $model->setAttribute('updated_by', $actorId);
+            }
+        });
+
+        static::updating(function (Model $model): void {
+            $actorId = Auth::id();
+
+            if ($actorId === null) {
+                return;
+            }
+
+            $model->setAttribute('updated_by', $actorId);
+        });
+
+        static::created(function (Model $model): void {
+            $model->dispatchAuditEvent('created', $model->getAttributes(), []);
+        });
+
+        static::updated(function (Model $model): void {
+            $model->dispatchAuditEvent('updated', $model->getChanges(), $model->getOriginal());
+        });
+
+        static::deleted(function (Model $model): void {
+            $model->dispatchAuditEvent('deleted', [], $model->getOriginal());
+        });
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    protected function dispatchAuditEvent(string $action, array $changes, array $original): void
+    {
+        event(new ModelAuditEvent($this, $action, Auth::id(), $changes, $original));
+    }
+}

--- a/Modules/Inventory/Models/StockMovement.php
+++ b/Modules/Inventory/Models/StockMovement.php
@@ -5,9 +5,12 @@ namespace Modules\Inventory\Models;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Core\Traits\HasAuditFields;
 
 class StockMovement extends Model
 {
+    use HasAuditFields;
+
     protected $fillable = [
         'stock_item_id',
         'movement_type',
@@ -20,6 +23,7 @@ class StockMovement extends Model
         'reference_id',
         'notes',
         'created_by',
+        'updated_by',
     ];
 
     public function stockItem(): BelongsTo

--- a/app/Models/GasBottleInspection.php
+++ b/app/Models/GasBottleInspection.php
@@ -6,10 +6,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Core\Traits\HasAuditFields;
 use Modules\Inventory\Models\StockItem;
 
 class GasBottleInspection extends Model
 {
+    use HasAuditFields;
+
     protected $fillable = [
         'stock_item_id',
         'scheduled_for',
@@ -17,6 +20,7 @@ class GasBottleInspection extends Model
         'outcome',
         'notes',
         'created_by',
+        'updated_by',
     ];
 
     public function stockItem(): BelongsTo

--- a/app/Models/GasBottleRental.php
+++ b/app/Models/GasBottleRental.php
@@ -6,10 +6,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Core\Traits\HasAuditFields;
 use Modules\Inventory\Models\StockItem;
 
 class GasBottleRental extends Model
 {
+    use HasAuditFields;
+
     protected $fillable = [
         'stock_item_id',
         'customer_id',
@@ -25,6 +28,7 @@ class GasBottleRental extends Model
         'rental_rate_period',
         'notes',
         'created_by',
+        'updated_by',
     ];
 
     public function stockItem(): BelongsTo

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -6,11 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Core\Traits\HasAuditFields;
 use Modules\Inventory\Models\Vendor;
 
 class PurchaseOrder extends Model
 {
     use SoftDeletes;
+    use HasAuditFields;
 
     protected $fillable = [
         'po_number',
@@ -26,6 +28,7 @@ class PurchaseOrder extends Model
         'total',
         'notes',
         'created_by',
+        'updated_by',
     ];
 
     public function vendor(): BelongsTo

--- a/database/migrations/2026_01_06_000002_add_updated_by_columns_to_audited_tables.php
+++ b/database/migrations/2026_01_06_000002_add_updated_by_columns_to_audited_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+// database/migrations/2026_01_06_000002_add_updated_by_columns_to_audited_tables.php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('gas_bottle_inspections', function (Blueprint $table) {
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete()->after('created_by');
+        });
+
+        Schema::table('gas_bottle_rentals', function (Blueprint $table) {
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete()->after('created_by');
+        });
+
+        Schema::table('purchase_orders', function (Blueprint $table) {
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete()->after('created_by');
+        });
+
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete()->after('created_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('gas_bottle_inspections', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('updated_by');
+        });
+
+        Schema::table('gas_bottle_rentals', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('updated_by');
+        });
+
+        Schema::table('purchase_orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('updated_by');
+        });
+
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('updated_by');
+        });
+    }
+};


### PR DESCRIPTION
### Motivation

- Introduce a consistent convention for tracking who created and last updated models across the app. 
- Auto-populate `created_by`/`updated_by` to reduce repetition and ensure correct actor attribution. 
- Emit a single model-level audit event to enable downstream immutable audit logging or hooks. 
- Prepare the database schema to store the `updated_by` metadata for audited tables.

### Description

- Add a reusable trait `HasAuditFields` that auto-sets `created_by` and `updated_by`, updates `updated_by` on save, exposes `createdBy()`/`updatedBy()` relations, and dispatches `ModelAuditEvent` on create/update/delete. (`Modules/Core/Traits/HasAuditFields.php`)
- Add a simple immutable audit payload class `ModelAuditEvent` to carry model, action, actor id, changes and original values. (`Modules/Core/Events/ModelAuditEvent.php`)
- Wire the trait into affected models by adding `use HasAuditFields` and including `updated_by` in `$fillable` for `GasBottleInspection`, `GasBottleRental`, `PurchaseOrder`, and `StockMovement`. (`app/Models/GasBottleInspection.php`, `app/Models/GasBottleRental.php`, `app/Models/PurchaseOrder.php`, `Modules/Inventory/Models/StockMovement.php`)
- Add a migration `database/migrations/2026_01_06_000002_add_updated_by_columns_to_audited_tables.php` to add nullable foreign keys `updated_by` to the audited tables and support rollback.

### Testing

- No automated tests were run for this change.
- (No additional automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696038c2daa48324ab9bf26a94da0ea6)