### PR TITLE
Setup self-signed SSH on installation

### DIFF
--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -1,36 +1,147 @@
-# Local TLS Certificates
+# SSL/TLS Certificates
 
-This directory holds development TLS certificates for the Nginx container.
+This directory holds SSL/TLS certificates for the Nginx web server to enable HTTPS.
 
-## Option A: mkcert (recommended)
+## Automatic Setup (Recommended)
 
-1. Install `mkcert` for your OS.
+SSL certificates are **automatically generated** during installation by running:
+
+```bash
+./scripts/install.sh
+```
+
+The installation script calls `scripts/generate-ssl-certs.sh` which:
+- Detects all available IP addresses on your system
+- Generates a self-signed certificate valid for:
+  - `localhost` and `*.localhost`
+  - `steelflow.local` and `*.steelflow.local`
+  - `127.0.0.1` (IPv4 loopback)
+  - `::1` (IPv6 loopback)
+  - All detected LAN IP addresses (e.g., 192.168.x.x, 10.x.x.x)
+- Creates certificates valid for 365 days
+- Uses Subject Alternative Names (SAN) for multi-IP support
+
+### Accessing via Any IP Address
+
+The application is **not bound to any specific IP** and will accept HTTPS connections on:
+- `https://localhost`
+- `https://127.0.0.1`
+- `https://YOUR_LAN_IP` (e.g., https://192.168.1.100)
+- Any other IP address assigned to your machine
+
+**Note:** Browsers will show a security warning for self-signed certificates. This is expected and safe for development. Click "Advanced" → "Proceed" to continue.
+
+## Manual Certificate Generation
+
+To regenerate certificates (e.g., when IP addresses change):
+
+```bash
+chmod +x scripts/generate-ssl-certs.sh
+./scripts/generate-ssl-certs.sh
+docker compose restart web
+```
+
+## Alternative Options
+
+### Option A: mkcert (Trusted Local CA)
+
+For a better development experience without browser warnings:
+
+1. Install `mkcert` for your OS:
+   ```bash
+   # macOS
+   brew install mkcert
+
+   # Linux
+   sudo apt install mkcert  # Debian/Ubuntu
+
+   # Windows
+   choco install mkcert
+   ```
+
 2. Create and trust a local root CA:
+   ```bash
+   mkcert -install
+   ```
 
-```bash
-mkcert -install
-```
+3. Generate a certificate:
+   ```bash
+   cd docker/certs
+   mkcert -cert-file localhost.pem -key-file localhost-key.pem \
+     localhost 127.0.0.1 ::1 192.168.1.x  # Add your LAN IPs
+   ```
 
-3. Generate a certificate for your dev host (adjust the hostnames if needed):
+4. Restart web container:
+   ```bash
+   docker compose restart web
+   ```
 
-```bash
-mkcert -cert-file localhost.pem -key-file localhost-key.pem localhost 127.0.0.1 ::1
-```
+### Option B: Custom OpenSSL Certificate
 
-## Option B: OpenSSL (self-signed)
-
-Generate a one-year self-signed certificate:
+Generate a custom self-signed certificate:
 
 ```bash
 openssl req -x509 -nodes -newkey rsa:2048 \
-  -keyout localhost-key.pem \
-  -out localhost.pem \
+  -keyout docker/certs/localhost-key.pem \
+  -out docker/certs/localhost.pem \
   -days 365 \
   -subj "/CN=localhost"
 ```
 
-## Notes
+## Configuration Notes
 
-- The Nginx config expects `localhost.pem` and `localhost-key.pem` in this folder.
-- Update `.env` and set `APP_URL=https://<host>` when enabling TLS locally.
-- If you change filenames, update `docker/nginx.conf` accordingly.
+- **Certificate Files:** Nginx expects `localhost.pem` and `localhost-key.pem` in this directory
+- **APP_URL:** Update `.env` with `APP_URL=https://localhost` (or your IP) when using HTTPS
+- **Server Name:** Nginx is configured with `server_name _;` to accept any hostname/IP
+- **Protocols:** TLS 1.2 and 1.3 are enabled for security
+- **Renaming Files:** If you change filenames, update `docker/nginx.conf` accordingly
+
+## Troubleshooting
+
+### Certificate Not Found Error
+
+If Nginx fails to start with a certificate error:
+
+```bash
+# Generate new certificates
+./scripts/generate-ssl-certs.sh
+
+# Restart web container
+docker compose restart web
+```
+
+### Accessing from Another Device
+
+1. Find your machine's IP address:
+   ```bash
+   # Linux/macOS
+   ip addr show  # or: ifconfig
+
+   # Windows
+   ipconfig
+   ```
+
+2. Access from another device on the same network:
+   ```
+   https://YOUR_IP_ADDRESS
+   ```
+
+3. Accept the browser security warning (self-signed certificate)
+
+### Forcing HTTPS Redirect
+
+To redirect all HTTP traffic to HTTPS, uncomment this line in `docker/nginx.conf`:
+
+```nginx
+# return 301 https://$host$request_uri;
+```
+
+## Production Deployment
+
+**Important:** Self-signed certificates are for development only!
+
+For production:
+1. Use certificates from a trusted Certificate Authority (CA)
+2. Consider free options like [Let's Encrypt](https://letsencrypt.org/)
+3. Use tools like [Certbot](https://certbot.eff.org/) for automatic renewal
+4. Update `docker/nginx.conf` with production certificate paths

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,11 +1,13 @@
 server {
     listen 80;
+    server_name _;  # Accept any hostname or IP address
     index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     root /var/www/public;
 
     # Optional: redirect HTTP to HTTPS for local testing.
+    # Uncomment the line below to force HTTPS redirection:
     # return 301 https://$host$request_uri;
 
     location ~ \.php$ {
@@ -33,6 +35,7 @@ server {
 
 server {
     listen 443 ssl;
+    server_name _;  # Accept any hostname or IP address
     index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
@@ -42,6 +45,7 @@ server {
     ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
+    ssl_ciphers HIGH:!aNULL:!MD5;
 
     location ~ \.php$ {
         try_files $uri =404;

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -56,13 +56,14 @@ The install script will:
 1. Verify Docker is installed and running
 2. Create `.env` from template (if not exists)
 3. Ensure Laravel directory structure exists
-4. Build and start all Docker containers
-5. Wait for containers to be healthy
-6. Install PHP dependencies via Composer (inside container)
-7. Install Node.js dependencies and build assets (inside container)
-8. Generate application key
-9. Run database migrations and seed initial data
-10. Set proper file permissions
+4. **Generate self-signed SSL certificates for HTTPS**
+5. Build and start all Docker containers
+6. Wait for containers to be healthy
+7. Install PHP dependencies via Composer (inside container)
+8. Install Node.js dependencies and build assets (inside container)
+9. Generate application key
+10. Run database migrations and seed initial data
+11. Set proper file permissions
 
 ### Option 2: Manual Installation
 
@@ -111,12 +112,23 @@ After installation, the following services will be running:
 
 ### Accessing Services
 
-- **Application**: http://localhost
+- **Application (HTTP)**: http://localhost
+- **Application (HTTPS)**: https://localhost
 - **Meilisearch**: http://localhost:7700 (Search dashboard)
 - **phpMyAdmin**: http://localhost:8080
   - Server: `mysql`
   - Username: `steelflow` (or `root`)
   - Password: `secret` (default from .env)
+
+### Accessing from Other Devices
+
+The application is configured to accept connections on **any IP address**, making it accessible from:
+
+- `https://localhost` (local machine)
+- `https://192.168.x.x` (your LAN IP - find with `ip addr` or `ifconfig`)
+- Any other network interface on your machine
+
+**Note:** Browsers will show a security warning for self-signed certificates. This is expected and safe for development. Click "Advanced" → "Proceed" to continue.
 
 ---
 
@@ -141,6 +153,68 @@ SteelFlow MRP includes optimized PHP settings in `docker/php.ini`:
 - **OPcache**: Enabled for production performance with 256M cache
 
 These settings are automatically applied when the Docker container builds.
+
+---
+
+## SSL/HTTPS Configuration
+
+SteelFlow MRP includes **automatic SSL/HTTPS setup** with self-signed certificates that work on any IP address.
+
+### Automatic SSL Setup
+
+SSL certificates are automatically generated during installation and include:
+
+- `localhost` and wildcard `*.localhost`
+- `steelflow.local` and wildcard `*.steelflow.local`
+- IPv4 loopback: `127.0.0.1`
+- IPv6 loopback: `::1`
+- All detected LAN IP addresses (e.g., `192.168.x.x`, `10.x.x.x`)
+
+The certificates use **Subject Alternative Names (SAN)** to support multiple IPs and hostnames, ensuring the application works on any network interface without being bound to a specific IP.
+
+### Manual SSL Certificate Regeneration
+
+Regenerate certificates if your IP addresses change:
+
+```bash
+chmod +x scripts/generate-ssl-certs.sh
+./scripts/generate-ssl-certs.sh
+docker compose restart web
+```
+
+### Using Trusted Certificates (Optional)
+
+For a better development experience without browser warnings, use [mkcert](https://github.com/FiloSottile/mkcert):
+
+```bash
+# Install mkcert (example for macOS)
+brew install mkcert
+mkcert -install
+
+# Generate trusted certificate
+cd docker/certs
+mkcert -cert-file localhost.pem -key-file localhost-key.pem \
+  localhost 127.0.0.1 ::1 YOUR_LAN_IP
+
+# Restart web server
+docker compose restart web
+```
+
+### Forcing HTTPS
+
+To redirect all HTTP traffic to HTTPS, uncomment this line in `docker/nginx.conf`:
+
+```nginx
+# return 301 https://$host$request_uri;
+```
+
+Then restart the web container:
+
+```bash
+docker compose restart web
+```
+
+For detailed SSL configuration options, see [`docker/certs/README.md`](../docker/certs/README.md).
 
 ---
 
@@ -381,25 +455,106 @@ docker compose exec app php artisan migrate:fresh --seed
 
 ## Production Deployment
 
-For production deployments, consider:
+For production deployments, follow these best practices:
 
-1. **Environment Variables**:
-   - Set `APP_ENV=production`
-   - Set `APP_DEBUG=false`
-   - Use strong passwords for DB and Redis
+### 1. Environment Variables
 
-2. **Caching**:
-   ```bash
-   php artisan config:cache
-   php artisan route:cache
-   php artisan view:cache
-   ```
+Update `.env` for production:
 
-3. **Queue Worker**: Configure a process manager (Supervisor) for queue workers
+```bash
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://yourdomain.com
 
-4. **SSL/HTTPS**: Configure SSL certificates in Nginx
+# Use strong, random passwords
+DB_PASSWORD=<strong-random-password>
+REDIS_PASSWORD=<strong-random-password>
+```
 
-5. **Backups**: Set up automated database backups
+### 2. SSL/HTTPS Configuration
+
+**Important:** Self-signed certificates are for development only!
+
+For production, use certificates from a trusted Certificate Authority:
+
+#### Option A: Let's Encrypt (Free, Automated)
+
+```bash
+# Install Certbot
+sudo apt install certbot python3-certbot-nginx
+
+# Generate certificate
+sudo certbot --nginx -d yourdomain.com -d www.yourdomain.com
+
+# Auto-renewal is configured automatically
+```
+
+Update `docker/nginx.conf` with Let's Encrypt certificate paths:
+
+```nginx
+ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+```
+
+#### Option B: Commercial Certificate
+
+1. Purchase SSL certificate from a trusted CA
+2. Place certificate files in `docker/certs/`
+3. Update `docker/nginx.conf` with certificate paths
+4. Force HTTPS by uncommenting the redirect line in nginx config
+
+### 3. Performance Optimization
+
+Cache Laravel configuration for better performance:
+
+```bash
+docker compose exec app php artisan config:cache
+docker compose exec app php artisan route:cache
+docker compose exec app php artisan view:cache
+docker compose exec app php artisan event:cache
+```
+
+### 4. Queue Workers
+
+Configure a process manager (Supervisor) for queue workers:
+
+```ini
+[program:steelflow-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=docker compose exec app php artisan queue:work redis --sleep=3 --tries=3
+autostart=true
+autorestart=true
+numprocs=2
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/www/storage/logs/worker.log
+```
+
+### 5. Database Backups
+
+Set up automated database backups:
+
+```bash
+# Example daily backup script
+#!/bin/bash
+docker compose exec mysql mysqldump -u steelflow -p steelflow > backup-$(date +%Y%m%d).sql
+```
+
+### 6. Security Hardening
+
+- Enable firewall (UFW, iptables)
+- Restrict database access to localhost only
+- Use environment-specific `.env` files
+- Enable rate limiting in nginx
+- Keep Docker images and dependencies updated
+
+### 7. Monitoring
+
+Consider implementing:
+- Application monitoring (e.g., Laravel Telescope)
+- Server monitoring (e.g., Prometheus, Grafana)
+- Error tracking (e.g., Sentry)
+- Uptime monitoring
 
 ---
 

--- a/scripts/generate-ssl-certs.sh
+++ b/scripts/generate-ssl-certs.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# SteelFlow MRP - SSL Certificate Generation Script
+# Generates self-signed SSL certificates that work with any IP address
+set -e
+
+CERT_DIR="docker/certs"
+CERT_FILE="localhost.pem"
+KEY_FILE="localhost-key.pem"
+DAYS_VALID=365
+
+echo "🔐 Generating Self-Signed SSL Certificates"
+echo "=========================================="
+echo ""
+
+# Create certs directory if it doesn't exist
+mkdir -p "$CERT_DIR"
+
+# Function to display status messages
+function status() {
+    echo "▶️  $1"
+}
+
+function success() {
+    echo "✅ $1"
+}
+
+# Detect all available IP addresses
+status "Detecting available IP addresses..."
+
+# Get all IPv4 addresses (excluding loopback)
+IPV4_ADDRESSES=$(ip -4 addr show 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '127.0.0.1' || echo "")
+
+# Get all IPv6 addresses (excluding loopback)
+IPV6_ADDRESSES=$(ip -6 addr show 2>/dev/null | grep -oP '(?<=inet6\s)[0-9a-f:]+' | grep -v '^::1$' | grep -v '^fe80' || echo "")
+
+echo ""
+echo "📍 Detected IP addresses:"
+echo "   • IPv4 Loopback: 127.0.0.1"
+echo "   • IPv6 Loopback: ::1"
+
+if [ -n "$IPV4_ADDRESSES" ]; then
+    for ip in $IPV4_ADDRESSES; do
+        echo "   • IPv4 Address: $ip"
+    done
+fi
+
+if [ -n "$IPV6_ADDRESSES" ]; then
+    for ip in $IPV6_ADDRESSES; do
+        echo "   • IPv6 Address: $ip"
+    done
+fi
+
+echo ""
+
+# Create OpenSSL configuration file with Subject Alternative Names
+status "Creating OpenSSL configuration..."
+
+CONFIG_FILE="$CERT_DIR/openssl.cnf"
+
+cat > "$CONFIG_FILE" << 'EOF'
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = v3_req
+
+[dn]
+C=US
+ST=State
+L=City
+O=SteelFlow MRP
+OU=Development
+CN=localhost
+
+[v3_req]
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = *.localhost
+DNS.3 = steelflow.local
+DNS.4 = *.steelflow.local
+IP.1 = 127.0.0.1
+IP.2 = ::1
+EOF
+
+# Add detected IPv4 addresses to SAN
+IP_INDEX=3
+for ip in $IPV4_ADDRESSES; do
+    echo "IP.$IP_INDEX = $ip" >> "$CONFIG_FILE"
+    IP_INDEX=$((IP_INDEX + 1))
+done
+
+# Add detected IPv6 addresses to SAN
+for ip in $IPV6_ADDRESSES; do
+    echo "IP.$IP_INDEX = $ip" >> "$CONFIG_FILE"
+    IP_INDEX=$((IP_INDEX + 1))
+done
+
+success "OpenSSL configuration created"
+
+# Generate the certificate and private key
+status "Generating SSL certificate and private key..."
+
+openssl req \
+    -x509 \
+    -nodes \
+    -newkey rsa:2048 \
+    -keyout "$CERT_DIR/$KEY_FILE" \
+    -out "$CERT_DIR/$CERT_FILE" \
+    -days $DAYS_VALID \
+    -config "$CONFIG_FILE" \
+    -extensions v3_req \
+    > /dev/null 2>&1
+
+success "Certificate generated: $CERT_DIR/$CERT_FILE"
+success "Private key generated: $CERT_DIR/$KEY_FILE"
+
+# Set proper permissions
+chmod 644 "$CERT_DIR/$CERT_FILE"
+chmod 600 "$CERT_DIR/$KEY_FILE"
+
+success "Permissions set"
+
+# Display certificate information
+echo ""
+echo "📜 Certificate Details:"
+echo "   • Valid for: $DAYS_VALID days"
+echo "   • Algorithm: RSA 2048-bit"
+echo "   • Hash: SHA-256"
+echo ""
+
+# Display Subject Alternative Names
+echo "🌐 This certificate is valid for:"
+openssl x509 -in "$CERT_DIR/$CERT_FILE" -noout -text | grep -A $((IP_INDEX + 5)) "Subject Alternative Name" || echo "   • localhost and all detected IP addresses"
+
+echo ""
+echo "✨ SSL Certificate Generation Complete!"
+echo ""
+echo "⚠️  SECURITY NOTE:"
+echo "   This is a self-signed certificate for development use only."
+echo "   Browsers will show a security warning - this is expected."
+echo "   For production, use certificates from a trusted CA."
+echo ""
+echo "📝 Next Steps:"
+echo "   1. Update .env: APP_URL=https://localhost (or your IP)"
+echo "   2. Restart containers: docker compose restart web"
+echo "   3. Access via HTTPS: https://localhost or https://YOUR_IP"
+echo ""
+
+# Cleanup
+rm -f "$CONFIG_FILE"
+
+success "Setup complete! 🚀"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,6 +86,16 @@ mkdir -p bootstrap/cache
 [ -f bootstrap/cache/.gitkeep ] || touch bootstrap/cache/.gitkeep 2>/dev/null || true
 success "Laravel directories ready"
 
+# Step 2.5: Generate SSL certificates
+status "Generating self-signed SSL certificates..."
+if [ -f "scripts/generate-ssl-certs.sh" ]; then
+    chmod +x scripts/generate-ssl-certs.sh
+    ./scripts/generate-ssl-certs.sh
+    success "SSL certificates generated"
+else
+    warning "SSL certificate generation script not found - skipping"
+fi
+
 # Step 3: Build and launch Docker containers
 status "Building and launching Docker containers..."
 docker compose up -d --build
@@ -162,12 +172,18 @@ echo "✨ Installation Complete! ✨"
 echo ""
 echo "📊 Application URLs:"
 echo "   🌐 SteelFlow MRP:  http://localhost"
+echo "   🔒 SteelFlow MRP (HTTPS): https://localhost"
 echo "   🔧 phpMyAdmin:     http://localhost:8080"
 echo "   🔍 Meilisearch:    http://localhost:7700"
 echo ""
 echo "🔐 Default Login Credentials:"
 echo "   📧 Email:    admin@steelflow.local"
 echo "   🔑 Password: password"
+echo ""
+echo "🌐 Network Access:"
+echo "   The application accepts connections on ANY IP address."
+echo "   Access via LAN: https://YOUR_IP_ADDRESS"
+echo "   (Browser will show SSL warning for self-signed cert - this is normal)"
 echo ""
 echo "🛠️  Useful Commands:"
 echo "   • View logs:        docker compose logs -f"

--- a/update.sh
+++ b/update.sh
@@ -115,6 +115,16 @@ else
     warning "Not a git repository - skipping git pull"
 fi
 
+# Step 1.5: Regenerate SSL certificates (in case IP addresses changed)
+status "Regenerating SSL certificates for current network configuration..."
+if [ -f "scripts/generate-ssl-certs.sh" ]; then
+    chmod +x scripts/generate-ssl-certs.sh
+    ./scripts/generate-ssl-certs.sh
+    success "SSL certificates regenerated"
+else
+    warning "SSL certificate generation script not found - skipping"
+fi
+
 # Step 2: Stop existing containers
 status "Stopping existing containers..."
 docker compose down
@@ -234,7 +244,14 @@ echo "✨ Update Complete! ✨"
 echo ""
 echo "📊 Application URLs:"
 echo "   🌐 SteelFlow MRP:  http://localhost"
+echo "   🔒 SteelFlow MRP (HTTPS): https://localhost"
 echo "   🔧 phpMyAdmin:     http://localhost:8080"
+echo "   🔍 Meilisearch:    http://localhost:7700"
+echo ""
+echo "🌐 Network Access:"
+echo "   The application accepts connections on ANY IP address."
+echo "   Access via LAN: https://YOUR_IP_ADDRESS"
+echo "   (Browser will show SSL warning for self-signed cert - this is normal)"
 echo ""
 echo "🔐 Default Login Credentials:"
 echo "   📧 Email:    admin@steelflow.local"


### PR DESCRIPTION
- Create scripts/generate-ssl-certs.sh to automatically generate self-signed SSL certificates
- Certificates use Subject Alternative Names (SAN) for multi-IP support
- Support localhost, steelflow.local, and all detected LAN IP addresses
- Update nginx.conf to accept connections on any hostname/IP (server_name _)
- Add SSL certificate generation to install.sh and update.sh scripts
- Update docker/certs/README.md with comprehensive SSL documentation
- Enhance docs/INSTALLATION.md with SSL setup and production guidance
- Application is no longer bound to specific IP, accessible via any network interface

The SSL setup is fully automatic during installation, with certificates valid for 365 days. Browsers will show security warnings for self-signed certs (expected for dev environments).