### PR TITLE
Integrate Filament 3 admin panel into Laravel

### DIFF
--- a/app/Enums/JobStatus.php
+++ b/app/Enums/JobStatus.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum JobStatus: string implements HasLabel, HasColor
+{
+    case Estimating = 'estimating';
+    case Awarded = 'awarded';
+    case InProgress = 'in_progress';
+    case Shipping = 'shipping';
+    case Complete = 'complete';
+    case Hold = 'hold';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Estimating => 'Estimating',
+            self::Awarded => 'Awarded',
+            self::InProgress => 'In Progress',
+            self::Shipping => 'Shipping',
+            self::Complete => 'Complete',
+            self::Hold => 'On Hold',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Estimating => 'gray',
+            self::Awarded => 'info',
+            self::InProgress => 'warning',
+            self::Shipping => 'primary',
+            self::Complete => 'success',
+            self::Hold => 'danger',
+        };
+    }
+}

--- a/app/Enums/MaterialType.php
+++ b/app/Enums/MaterialType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum MaterialType: string implements HasLabel
+{
+    case Plate = 'plate';
+    case Beam = 'beam';
+    case Channel = 'channel';
+    case Angle = 'angle';
+    case Tube = 'tube';
+    case Pipe = 'pipe';
+    case Bar = 'bar';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Plate => 'Plate',
+            self::Beam => 'Beam (W/S/HP)',
+            self::Channel => 'Channel',
+            self::Angle => 'Angle',
+            self::Tube => 'Tube (HSS)',
+            self::Pipe => 'Pipe',
+            self::Bar => 'Bar',
+        };
+    }
+}

--- a/app/Enums/PartStatus.php
+++ b/app/Enums/PartStatus.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum PartStatus: string implements HasLabel, HasColor
+{
+    case Pending = 'pending';
+    case Nested = 'nested';
+    case Cutting = 'cutting';
+    case Fabrication = 'fabrication';
+    case Complete = 'complete';
+    case Shipped = 'shipped';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Nested => 'Nested',
+            self::Cutting => 'Cutting',
+            self::Fabrication => 'Fabrication',
+            self::Complete => 'Complete',
+            self::Shipped => 'Shipped',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Pending => 'gray',
+            self::Nested => 'info',
+            self::Cutting => 'warning',
+            self::Fabrication => 'primary',
+            self::Complete => 'success',
+            self::Shipped => 'success',
+        };
+    }
+}

--- a/app/Filament/Exports/FabJobExporter.php
+++ b/app/Filament/Exports/FabJobExporter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\FabJob;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+
+class FabJobExporter extends Exporter
+{
+    protected static ?string $model = FabJob::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id')
+                ->label('ID'),
+
+            ExportColumn::make('job_number')
+                ->label('Job Number'),
+
+            ExportColumn::make('customer_name')
+                ->label('Customer'),
+
+            ExportColumn::make('description')
+                ->label('Description'),
+
+            ExportColumn::make('status')
+                ->label('Status')
+                ->formatStateUsing(fn ($state) => $state?->getLabel()),
+
+            ExportColumn::make('due_date')
+                ->label('Due Date'),
+
+            ExportColumn::make('parts_count')
+                ->label('Total Parts')
+                ->counts('parts'),
+
+            ExportColumn::make('created_at')
+                ->label('Created'),
+
+            ExportColumn::make('updated_at')
+                ->label('Updated'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Your job export has completed and ' . number_format($export->successful_rows) . ' ' . str('row')->plural($export->successful_rows) . ' exported.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' ' . number_format($failedRowsCount) . ' ' . str('row')->plural($failedRowsCount) . ' failed to export.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Exports/FabPartExporter.php
+++ b/app/Filament/Exports/FabPartExporter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\FabPart;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+
+class FabPartExporter extends Exporter
+{
+    protected static ?string $model = FabPart::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id')
+                ->label('ID'),
+
+            ExportColumn::make('fabJob.job_number')
+                ->label('Job Number'),
+
+            ExportColumn::make('mark_number')
+                ->label('Mark Number'),
+
+            ExportColumn::make('description')
+                ->label('Description'),
+
+            ExportColumn::make('quantity')
+                ->label('Quantity'),
+
+            ExportColumn::make('material_grade')
+                ->label('Material Grade'),
+
+            ExportColumn::make('weight_each')
+                ->label('Weight Each (lbs)'),
+
+            ExportColumn::make('status')
+                ->label('Status')
+                ->formatStateUsing(fn ($state) => $state?->getLabel()),
+
+            ExportColumn::make('created_at')
+                ->label('Created'),
+
+            ExportColumn::make('updated_at')
+                ->label('Updated'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Your parts export has completed and ' . number_format($export->successful_rows) . ' ' . str('row')->plural($export->successful_rows) . ' exported.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' ' . number_format($failedRowsCount) . ' ' . str('row')->plural($failedRowsCount) . ' failed to export.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/BomItemResource.php
+++ b/app/Filament/Resources/BomItemResource.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BomItemResource\Pages;
+use App\Models\BomItem;
+use App\Models\RawMaterial;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class BomItemResource extends Resource
+{
+    protected static ?string $model = BomItem::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-list-bullet';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Production';
+
+    protected static ?string $navigationLabel = 'BOM Items';
+
+    protected static ?string $modelLabel = 'BOM Item';
+
+    protected static ?int $navigationSort = 3;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('BOM Item Details')
+                ->schema([
+                    Select::make('fab_part_id')
+                        ->label('Part')
+                        ->relationship('fabPart', 'mark_number', fn ($query) => $query->with('fabJob'))
+                        ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->fabJob->job_number} - {$record->mark_number}")
+                        ->searchable()
+                        ->preload()
+                        ->required(),
+
+                    Select::make('raw_material_id')
+                        ->label('Material')
+                        ->options(fn () => RawMaterial::all()->pluck('display_name', 'id'))
+                        ->searchable()
+                        ->required(),
+
+                    TextInput::make('quantity_required')
+                        ->label('Quantity Required')
+                        ->numeric()
+                        ->required()
+                        ->default(1)
+                        ->minValue(1),
+
+                    TextInput::make('cut_length')
+                        ->label('Cut Length')
+                        ->numeric()
+                        ->suffix('ft')
+                        ->step(0.0001),
+                ])->columns(2),
+
+            Section::make('Notes')
+                ->schema([
+                    Textarea::make('notes')
+                        ->rows(2)
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('fabPart.fabJob.job_number')
+                    ->label('Job')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('fabPart.mark_number')
+                    ->label('Part Mark')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('rawMaterial.display_name')
+                    ->label('Material')
+                    ->limit(40)
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('quantity_required')
+                    ->label('Qty Req')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('cut_length')
+                    ->label('Cut Length')
+                    ->numeric(decimalPlaces: 4)
+                    ->suffix(' ft')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('rawMaterial.quantity_on_hand')
+                    ->label('In Stock')
+                    ->sortable()
+                    ->color(fn ($record) => $record->rawMaterial?->isLowStock() ? 'danger' : null),
+
+                Tables\Columns\TextColumn::make('notes')
+                    ->limit(30)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('fab_part_id')
+                    ->label('Part')
+                    ->relationship('fabPart', 'mark_number')
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\SelectFilter::make('raw_material_id')
+                    ->label('Material')
+                    ->relationship('rawMaterial', 'size_description')
+                    ->searchable()
+                    ->preload(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBomItems::route('/'),
+            'create' => Pages\CreateBomItem::route('/create'),
+            'edit' => Pages\EditBomItem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BomItemResource/Pages/CreateBomItem.php
+++ b/app/Filament/Resources/BomItemResource/Pages/CreateBomItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\BomItemResource\Pages;
+
+use App\Filament\Resources\BomItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBomItem extends CreateRecord
+{
+    protected static string $resource = BomItemResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/BomItemResource/Pages/EditBomItem.php
+++ b/app/Filament/Resources/BomItemResource/Pages/EditBomItem.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\BomItemResource\Pages;
+
+use App\Filament\Resources\BomItemResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBomItem extends EditRecord
+{
+    protected static string $resource = BomItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/BomItemResource/Pages/ListBomItems.php
+++ b/app/Filament/Resources/BomItemResource/Pages/ListBomItems.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\BomItemResource\Pages;
+
+use App\Filament\Resources\BomItemResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBomItems extends ListRecords
+{
+    protected static string $resource = BomItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FabJobResource.php
+++ b/app/Filament/Resources/FabJobResource.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\JobStatus;
+use App\Filament\Resources\FabJobResource\Pages;
+use App\Models\FabJob;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class FabJobResource extends Resource
+{
+    protected static ?string $model = FabJob::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Production';
+
+    protected static ?string $navigationLabel = 'Jobs';
+
+    protected static ?string $modelLabel = 'Job';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Job Information')
+                ->schema([
+                    TextInput::make('job_number')
+                        ->required()
+                        ->unique(ignoreRecord: true)
+                        ->maxLength(30)
+                        ->placeholder('J2024-001'),
+
+                    TextInput::make('customer_name')
+                        ->required()
+                        ->maxLength(255),
+
+                    Select::make('status')
+                        ->options(JobStatus::class)
+                        ->required()
+                        ->default(JobStatus::Estimating),
+
+                    DatePicker::make('due_date')
+                        ->native(false),
+                ])->columns(2),
+
+            Section::make('Description')
+                ->schema([
+                    Textarea::make('description')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('job_number')
+                    ->searchable()
+                    ->sortable()
+                    ->copyable(),
+
+                Tables\Columns\TextColumn::make('customer_name')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(30),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('parts_count')
+                    ->label('Parts')
+                    ->counts('parts')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('due_date')
+                    ->date()
+                    ->sortable()
+                    ->color(fn (FabJob $record) => $record->due_date && $record->due_date->isPast() ? 'danger' : null),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(JobStatus::class)
+                    ->multiple(),
+
+                Tables\Filters\Filter::make('overdue')
+                    ->query(fn ($query) => $query->where('due_date', '<', now())->where('status', '!=', JobStatus::Complete))
+                    ->label('Overdue Jobs'),
+
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+                Tables\Actions\ExportBulkAction::make()
+                    ->exporter(\App\Filament\Exports\FabJobExporter::class),
+            ])
+            ->headerActions([
+                Tables\Actions\ExportAction::make()
+                    ->exporter(\App\Filament\Exports\FabJobExporter::class),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            FabJobResource\RelationManagers\PartsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListFabJobs::route('/'),
+            'create' => Pages\CreateFabJob::route('/create'),
+            'view' => Pages\ViewFabJob::route('/{record}'),
+            'edit' => Pages\EditFabJob::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::where('status', JobStatus::InProgress)->count() ?: null;
+    }
+}

--- a/app/Filament/Resources/FabJobResource/Pages/CreateFabJob.php
+++ b/app/Filament/Resources/FabJobResource/Pages/CreateFabJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\FabJobResource\Pages;
+
+use App\Filament\Resources\FabJobResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFabJob extends CreateRecord
+{
+    protected static string $resource = FabJobResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/FabJobResource/Pages/EditFabJob.php
+++ b/app/Filament/Resources/FabJobResource/Pages/EditFabJob.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Resources\FabJobResource\Pages;
+
+use App\Filament\Resources\FabJobResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFabJob extends EditRecord
+{
+    protected static string $resource = FabJobResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/FabJobResource/Pages/ListFabJobs.php
+++ b/app/Filament/Resources/FabJobResource/Pages/ListFabJobs.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FabJobResource\Pages;
+
+use App\Filament\Resources\FabJobResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFabJobs extends ListRecords
+{
+    protected static string $resource = FabJobResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FabJobResource/Pages/ViewFabJob.php
+++ b/app/Filament/Resources/FabJobResource/Pages/ViewFabJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FabJobResource\Pages;
+
+use App\Filament\Resources\FabJobResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewFabJob extends ViewRecord
+{
+    protected static string $resource = FabJobResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FabJobResource/RelationManagers/PartsRelationManager.php
+++ b/app/Filament/Resources/FabJobResource/RelationManagers/PartsRelationManager.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\FabJobResource\RelationManagers;
+
+use App\Enums\PartStatus;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PartsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'parts';
+
+    protected static ?string $recordTitleAttribute = 'mark_number';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('mark_number')
+                ->required()
+                ->maxLength(30),
+
+            TextInput::make('description')
+                ->maxLength(255),
+
+            TextInput::make('quantity')
+                ->numeric()
+                ->required()
+                ->default(1)
+                ->minValue(1),
+
+            TextInput::make('material_grade')
+                ->default('A36')
+                ->maxLength(30),
+
+            TextInput::make('weight_each')
+                ->numeric()
+                ->suffix('lbs'),
+
+            Select::make('status')
+                ->options(PartStatus::class)
+                ->default(PartStatus::Pending)
+                ->required(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('mark_number')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('description')
+                    ->limit(30),
+
+                Tables\Columns\TextColumn::make('quantity')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('material_grade'),
+
+                Tables\Columns\TextColumn::make('weight_each')
+                    ->numeric(decimalPlaces: 2)
+                    ->suffix(' lbs'),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(PartStatus::class),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\BulkAction::make('updateStatus')
+                        ->label('Update Status')
+                        ->icon('heroicon-o-arrow-path')
+                        ->form([
+                            Select::make('status')
+                                ->options(PartStatus::class)
+                                ->required(),
+                        ])
+                        ->action(function (array $data, $records): void {
+                            foreach ($records as $record) {
+                                $record->update(['status' => $data['status']]);
+                            }
+                        })
+                        ->deselectRecordsAfterCompletion(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/FabPartResource.php
+++ b/app/Filament/Resources/FabPartResource.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\PartStatus;
+use App\Filament\Resources\FabPartResource\Pages;
+use App\Models\FabPart;
+use App\Models\RawMaterial;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class FabPartResource extends Resource
+{
+    protected static ?string $model = FabPart::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cube';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Production';
+
+    protected static ?string $navigationLabel = 'Parts';
+
+    protected static ?string $modelLabel = 'Part';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Part Information')
+                ->schema([
+                    Select::make('fab_job_id')
+                        ->label('Job')
+                        ->relationship('fabJob', 'job_number')
+                        ->searchable()
+                        ->preload()
+                        ->required()
+                        ->createOptionForm([
+                            TextInput::make('job_number')
+                                ->required()
+                                ->unique(),
+                            TextInput::make('customer_name')
+                                ->required(),
+                        ]),
+
+                    TextInput::make('mark_number')
+                        ->required()
+                        ->maxLength(30)
+                        ->placeholder('B1, C2, etc.'),
+
+                    TextInput::make('description')
+                        ->maxLength(255)
+                        ->columnSpanFull(),
+                ])->columns(2),
+
+            Section::make('Specifications')
+                ->schema([
+                    TextInput::make('quantity')
+                        ->numeric()
+                        ->required()
+                        ->default(1)
+                        ->minValue(1),
+
+                    TextInput::make('material_grade')
+                        ->default('A36')
+                        ->maxLength(30)
+                        ->datalist([
+                            'A36',
+                            'A572-50',
+                            'A992',
+                            'A500B',
+                            'A500C',
+                            'A53B',
+                        ]),
+
+                    TextInput::make('weight_each')
+                        ->numeric()
+                        ->suffix('lbs')
+                        ->step(0.01),
+
+                    Select::make('status')
+                        ->options(PartStatus::class)
+                        ->default(PartStatus::Pending)
+                        ->required(),
+                ])->columns(2),
+
+            Section::make('Bill of Materials')
+                ->schema([
+                    Repeater::make('bomItems')
+                        ->relationship()
+                        ->schema([
+                            Select::make('raw_material_id')
+                                ->label('Material')
+                                ->options(fn () => RawMaterial::all()->pluck('display_name', 'id'))
+                                ->searchable()
+                                ->required()
+                                ->columnSpan(2),
+
+                            TextInput::make('quantity_required')
+                                ->label('Qty')
+                                ->numeric()
+                                ->default(1)
+                                ->minValue(1)
+                                ->required(),
+
+                            TextInput::make('cut_length')
+                                ->label('Cut Length')
+                                ->numeric()
+                                ->step(0.0001)
+                                ->suffix('ft'),
+
+                            TextInput::make('notes')
+                                ->maxLength(255)
+                                ->columnSpan(2),
+                        ])
+                        ->columns(6)
+                        ->defaultItems(0)
+                        ->addActionLabel('Add Material')
+                        ->reorderable(false)
+                        ->collapsible()
+                        ->itemLabel(fn (array $state): ?string =>
+                            $state['raw_material_id']
+                                ? RawMaterial::find($state['raw_material_id'])?->display_name
+                                : null
+                        ),
+                ])
+                ->collapsible(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('fabJob.job_number')
+                    ->label('Job')
+                    ->sortable()
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('mark_number')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('description')
+                    ->limit(30)
+                    ->toggleable(),
+
+                Tables\Columns\TextColumn::make('quantity')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('material_grade')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('weight_each')
+                    ->numeric(decimalPlaces: 2)
+                    ->suffix(' lbs')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('bomItems_count')
+                    ->label('BOM Items')
+                    ->counts('bomItems')
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('fab_job_id')
+                    ->label('Job')
+                    ->relationship('fabJob', 'job_number')
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(PartStatus::class)
+                    ->multiple(),
+
+                Tables\Filters\SelectFilter::make('material_grade')
+                    ->options([
+                        'A36' => 'A36',
+                        'A572-50' => 'A572-50',
+                        'A992' => 'A992',
+                        'A500B' => 'A500B',
+                        'A500C' => 'A500C',
+                    ])
+                    ->multiple(),
+
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('updateStatus')
+                    ->label('Update Status')
+                    ->icon('heroicon-o-arrow-path')
+                    ->form([
+                        Select::make('status')
+                            ->options(PartStatus::class)
+                            ->required(),
+                    ])
+                    ->action(fn (FabPart $record, array $data) => $record->update(['status' => $data['status']])),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+                Tables\Actions\BulkAction::make('bulkUpdateStatus')
+                    ->label('Update Status')
+                    ->icon('heroicon-o-arrow-path')
+                    ->form([
+                        Select::make('status')
+                            ->options(PartStatus::class)
+                            ->required(),
+                    ])
+                    ->action(function (array $data, $records): void {
+                        foreach ($records as $record) {
+                            $record->update(['status' => $data['status']]);
+                        }
+                    })
+                    ->deselectRecordsAfterCompletion(),
+                Tables\Actions\ExportBulkAction::make()
+                    ->exporter(\App\Filament\Exports\FabPartExporter::class),
+            ])
+            ->headerActions([
+                Tables\Actions\ExportAction::make()
+                    ->exporter(\App\Filament\Exports\FabPartExporter::class),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListFabParts::route('/'),
+            'create' => Pages\CreateFabPart::route('/create'),
+            'edit' => Pages\EditFabPart::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::where('status', PartStatus::Pending)->count() ?: null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
+}

--- a/app/Filament/Resources/FabPartResource/Pages/CreateFabPart.php
+++ b/app/Filament/Resources/FabPartResource/Pages/CreateFabPart.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\FabPartResource\Pages;
+
+use App\Filament\Resources\FabPartResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFabPart extends CreateRecord
+{
+    protected static string $resource = FabPartResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/FabPartResource/Pages/EditFabPart.php
+++ b/app/Filament/Resources/FabPartResource/Pages/EditFabPart.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\FabPartResource\Pages;
+
+use App\Filament\Resources\FabPartResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFabPart extends EditRecord
+{
+    protected static string $resource = FabPartResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/FabPartResource/Pages/ListFabParts.php
+++ b/app/Filament/Resources/FabPartResource/Pages/ListFabParts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FabPartResource\Pages;
+
+use App\Filament\Resources\FabPartResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFabParts extends ListRecords
+{
+    protected static string $resource = FabPartResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProductionItemResource.php
+++ b/app/Filament/Resources/ProductionItemResource.php
@@ -22,9 +22,9 @@ class ProductionItemResource extends Resource
 {
     protected static ?string $model = ProductionItem::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-wrench-screwdriver';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-wrench-screwdriver';
 
-    protected static ?string $navigationGroup = 'Production';
+    protected static string|\UnitEnum|null $navigationGroup = 'Production';
 
     protected static ?int $navigationSort = 1;
 

--- a/app/Filament/Resources/RawMaterialResource.php
+++ b/app/Filament/Resources/RawMaterialResource.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\MaterialType;
+use App\Filament\Resources\RawMaterialResource\Pages;
+use App\Models\RawMaterial;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class RawMaterialResource extends Resource
+{
+    protected static ?string $model = RawMaterial::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-archive-box';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Inventory';
+
+    protected static ?string $navigationLabel = 'Materials';
+
+    protected static ?string $modelLabel = 'Material';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Material Information')
+                ->schema([
+                    Select::make('material_type')
+                        ->options(MaterialType::class)
+                        ->required()
+                        ->native(false),
+
+                    TextInput::make('size_description')
+                        ->required()
+                        ->maxLength(100)
+                        ->placeholder('W10x26, L4x4x1/4, etc.'),
+
+                    TextInput::make('grade')
+                        ->required()
+                        ->default('A36')
+                        ->maxLength(30)
+                        ->datalist([
+                            'A36',
+                            'A572-50',
+                            'A992',
+                            'A500B',
+                            'A500C',
+                            'A53B',
+                        ]),
+
+                    TextInput::make('length_stock')
+                        ->label('Stock Length')
+                        ->numeric()
+                        ->suffix('ft')
+                        ->step(0.0001)
+                        ->placeholder('20, 40, etc.'),
+                ])->columns(2),
+
+            Section::make('Inventory')
+                ->schema([
+                    TextInput::make('quantity_on_hand')
+                        ->label('Quantity On Hand')
+                        ->numeric()
+                        ->required()
+                        ->default(0)
+                        ->minValue(0),
+
+                    TextInput::make('location')
+                        ->maxLength(100)
+                        ->placeholder('Bay A-1, Rack 3, etc.'),
+                ])->columns(2),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('material_type')
+                    ->badge()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('size_description')
+                    ->label('Size')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('grade')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('length_stock')
+                    ->label('Length')
+                    ->numeric(decimalPlaces: 2)
+                    ->suffix(' ft')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('quantity_on_hand')
+                    ->label('Qty')
+                    ->sortable()
+                    ->color(fn (RawMaterial $record) => $record->isLowStock() ? 'danger' : null)
+                    ->weight(fn (RawMaterial $record) => $record->isLowStock() ? 'bold' : null),
+
+                Tables\Columns\TextColumn::make('location')
+                    ->searchable()
+                    ->toggleable(),
+
+                Tables\Columns\IconColumn::make('low_stock')
+                    ->label('Low Stock')
+                    ->boolean()
+                    ->getStateUsing(fn (RawMaterial $record) => $record->isLowStock())
+                    ->trueIcon('heroicon-o-exclamation-triangle')
+                    ->trueColor('danger')
+                    ->falseIcon('heroicon-o-check-circle')
+                    ->falseColor('success'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('material_type')
+                    ->options(MaterialType::class)
+                    ->multiple(),
+
+                Tables\Filters\SelectFilter::make('grade')
+                    ->options([
+                        'A36' => 'A36',
+                        'A572-50' => 'A572-50',
+                        'A992' => 'A992',
+                        'A500B' => 'A500B',
+                        'A500C' => 'A500C',
+                    ])
+                    ->multiple(),
+
+                Tables\Filters\Filter::make('low_stock')
+                    ->query(fn (Builder $query) => $query->where('quantity_on_hand', '<', 5))
+                    ->label('Low Stock Only'),
+
+                Tables\Filters\Filter::make('out_of_stock')
+                    ->query(fn (Builder $query) => $query->where('quantity_on_hand', '=', 0))
+                    ->label('Out of Stock'),
+
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('adjustQuantity')
+                    ->label('Adjust Qty')
+                    ->icon('heroicon-o-plus-minus')
+                    ->form([
+                        TextInput::make('adjustment')
+                            ->label('Adjustment (+/-)')
+                            ->numeric()
+                            ->required()
+                            ->helperText('Positive to add, negative to subtract'),
+                    ])
+                    ->action(function (RawMaterial $record, array $data): void {
+                        $newQty = max(0, $record->quantity_on_hand + (int) $data['adjustment']);
+                        $record->update(['quantity_on_hand' => $newQty]);
+                    }),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('size_description');
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRawMaterials::route('/'),
+            'create' => Pages\CreateRawMaterial::route('/create'),
+            'edit' => Pages\EditRawMaterial::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $lowStockCount = static::getModel()::where('quantity_on_hand', '<', 5)->count();
+
+        return $lowStockCount > 0 ? (string) $lowStockCount : null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'danger';
+    }
+}

--- a/app/Filament/Resources/RawMaterialResource/Pages/CreateRawMaterial.php
+++ b/app/Filament/Resources/RawMaterialResource/Pages/CreateRawMaterial.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\RawMaterialResource\Pages;
+
+use App\Filament\Resources\RawMaterialResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRawMaterial extends CreateRecord
+{
+    protected static string $resource = RawMaterialResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/RawMaterialResource/Pages/EditRawMaterial.php
+++ b/app/Filament/Resources/RawMaterialResource/Pages/EditRawMaterial.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\RawMaterialResource\Pages;
+
+use App\Filament\Resources\RawMaterialResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRawMaterial extends EditRecord
+{
+    protected static string $resource = RawMaterialResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/RawMaterialResource/Pages/ListRawMaterials.php
+++ b/app/Filament/Resources/RawMaterialResource/Pages/ListRawMaterials.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\RawMaterialResource\Pages;
+
+use App\Filament\Resources\RawMaterialResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRawMaterials extends ListRecords
+{
+    protected static string $resource = RawMaterialResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Widgets/JobsStatusChart.php
+++ b/app/Filament/Widgets/JobsStatusChart.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Enums\JobStatus;
+use App\Models\FabJob;
+use Filament\Widgets\ChartWidget;
+
+class JobsStatusChart extends ChartWidget
+{
+    protected ?string $heading = 'Jobs by Status';
+
+    protected int|string|array $columnSpan = 'half';
+
+    protected function getData(): array
+    {
+        $data = collect(JobStatus::cases())->map(function ($status) {
+            return FabJob::where('status', $status)->count();
+        });
+
+        $labels = collect(JobStatus::cases())->map(fn ($status) => $status->getLabel());
+
+        $colors = [
+            '#6b7280', // gray - estimating
+            '#3b82f6', // blue - awarded
+            '#f59e0b', // amber - in_progress
+            '#8b5cf6', // violet - shipping
+            '#22c55e', // green - complete
+            '#ef4444', // red - hold
+        ];
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Jobs',
+                    'data' => $data->toArray(),
+                    'backgroundColor' => $colors,
+                    'borderColor' => $colors,
+                ],
+            ],
+            'labels' => $labels->toArray(),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'doughnut';
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            'plugins' => [
+                'legend' => [
+                    'position' => 'right',
+                ],
+            ],
+        ];
+    }
+
+    public static function getSort(): int
+    {
+        return 1;
+    }
+}

--- a/app/Filament/Widgets/LowStockAlert.php
+++ b/app/Filament/Widgets/LowStockAlert.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\RawMaterial;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class LowStockAlert extends BaseWidget
+{
+    protected static ?string $heading = 'Low Stock Materials';
+
+    protected int|string|array $columnSpan = 'half';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                RawMaterial::query()
+                    ->where('quantity_on_hand', '<', 5)
+                    ->orderBy('quantity_on_hand')
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('material_type')
+                    ->badge(),
+
+                Tables\Columns\TextColumn::make('size_description')
+                    ->label('Size')
+                    ->limit(20),
+
+                Tables\Columns\TextColumn::make('grade'),
+
+                Tables\Columns\TextColumn::make('quantity_on_hand')
+                    ->label('Qty')
+                    ->color('danger')
+                    ->weight('bold'),
+
+                Tables\Columns\TextColumn::make('location'),
+            ])
+            ->paginated([5, 10, 25])
+            ->defaultPaginationPageOption(5)
+            ->emptyStateHeading('All materials stocked')
+            ->emptyStateDescription('No materials are currently low in stock.')
+            ->emptyStateIcon('heroicon-o-check-circle');
+    }
+
+    public static function getSort(): int
+    {
+        return 3;
+    }
+}

--- a/app/Filament/Widgets/PendingPartsStats.php
+++ b/app/Filament/Widgets/PendingPartsStats.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Enums\PartStatus;
+use App\Models\FabPart;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class PendingPartsStats extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $pendingCount = FabPart::where('status', PartStatus::Pending)->count();
+        $cuttingCount = FabPart::where('status', PartStatus::Cutting)->count();
+        $fabricationCount = FabPart::where('status', PartStatus::Fabrication)->count();
+        $completeToday = FabPart::where('status', PartStatus::Complete)
+            ->whereDate('updated_at', today())
+            ->count();
+
+        return [
+            Stat::make('Pending Parts', $pendingCount)
+                ->description('Awaiting processing')
+                ->descriptionIcon('heroicon-m-clock')
+                ->color('warning')
+                ->chart([7, 3, 4, 5, 6, 3, $pendingCount]),
+
+            Stat::make('In Cutting', $cuttingCount)
+                ->description('Currently being cut')
+                ->descriptionIcon('heroicon-m-scissors')
+                ->color('info'),
+
+            Stat::make('In Fabrication', $fabricationCount)
+                ->description('Being fabricated')
+                ->descriptionIcon('heroicon-m-wrench-screwdriver')
+                ->color('primary'),
+
+            Stat::make('Completed Today', $completeToday)
+                ->description('Parts finished today')
+                ->descriptionIcon('heroicon-m-check-circle')
+                ->color('success'),
+        ];
+    }
+
+    public static function getSort(): int
+    {
+        return 2;
+    }
+}

--- a/app/Models/BomItem.php
+++ b/app/Models/BomItem.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BomItem extends Model
+{
+    protected $fillable = [
+        'fab_part_id',
+        'raw_material_id',
+        'quantity_required',
+        'cut_length',
+        'notes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity_required' => 'integer',
+            'cut_length' => 'decimal:4',
+        ];
+    }
+
+    public function fabPart(): BelongsTo
+    {
+        return $this->belongsTo(FabPart::class);
+    }
+
+    public function rawMaterial(): BelongsTo
+    {
+        return $this->belongsTo(RawMaterial::class);
+    }
+}

--- a/app/Models/FabJob.php
+++ b/app/Models/FabJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FabJob extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'job_number',
+        'customer_name',
+        'description',
+        'status',
+        'due_date',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => JobStatus::class,
+            'due_date' => 'date',
+        ];
+    }
+
+    public function parts(): HasMany
+    {
+        return $this->hasMany(FabPart::class);
+    }
+
+    public function getTotalPartsAttribute(): int
+    {
+        return $this->parts()->sum('quantity');
+    }
+
+    public function getTotalWeightAttribute(): float
+    {
+        return $this->parts()->sum(\DB::raw('weight_each * quantity')) ?? 0;
+    }
+}

--- a/app/Models/FabPart.php
+++ b/app/Models/FabPart.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\PartStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FabPart extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'fab_job_id',
+        'mark_number',
+        'description',
+        'quantity',
+        'material_grade',
+        'weight_each',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => PartStatus::class,
+            'quantity' => 'integer',
+            'weight_each' => 'decimal:4',
+        ];
+    }
+
+    public function fabJob(): BelongsTo
+    {
+        return $this->belongsTo(FabJob::class);
+    }
+
+    public function bomItems(): HasMany
+    {
+        return $this->hasMany(BomItem::class);
+    }
+
+    public function getTotalWeightAttribute(): float
+    {
+        return ($this->weight_each ?? 0) * $this->quantity;
+    }
+}

--- a/app/Models/RawMaterial.php
+++ b/app/Models/RawMaterial.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MaterialType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class RawMaterial extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'material_type',
+        'size_description',
+        'grade',
+        'length_stock',
+        'quantity_on_hand',
+        'location',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'material_type' => MaterialType::class,
+            'length_stock' => 'decimal:4',
+            'quantity_on_hand' => 'integer',
+        ];
+    }
+
+    public function bomItems(): HasMany
+    {
+        return $this->hasMany(BomItem::class);
+    }
+
+    public function isLowStock(): bool
+    {
+        return $this->quantity_on_hand < 5;
+    }
+
+    public function getDisplayNameAttribute(): string
+    {
+        return "{$this->material_type->getLabel()} - {$this->size_description} ({$this->grade})";
+    }
+}

--- a/database/migrations/2026_01_09_000001_create_filament_mrp_tables.php
+++ b/database/migrations/2026_01_09_000001_create_filament_mrp_tables.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Fabrication Jobs - Main work orders
+        Schema::create('fab_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('job_number', 30)->unique();
+            $table->string('customer_name', 255);
+            $table->text('description')->nullable();
+            $table->string('status', 20)->default('estimating');
+            $table->date('due_date')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('status');
+            $table->index('due_date');
+        });
+
+        // Raw Materials - Stock inventory
+        Schema::create('raw_materials', function (Blueprint $table) {
+            $table->id();
+            $table->string('material_type', 20);
+            $table->string('size_description', 100);
+            $table->string('grade', 30)->default('A36');
+            $table->decimal('length_stock', 12, 4)->nullable();
+            $table->integer('quantity_on_hand')->default(0);
+            $table->string('location', 100)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['material_type', 'grade']);
+            $table->index('quantity_on_hand');
+        });
+
+        // Fabricated Parts - Individual pieces belonging to jobs
+        Schema::create('fab_parts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('fab_job_id')->constrained('fab_jobs')->cascadeOnDelete();
+            $table->string('mark_number', 30);
+            $table->text('description')->nullable();
+            $table->integer('quantity')->default(1);
+            $table->string('material_grade', 30)->default('A36');
+            $table->decimal('weight_each', 12, 4)->nullable();
+            $table->string('status', 20)->default('pending');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['fab_job_id', 'status']);
+            $table->index('status');
+            $table->unique(['fab_job_id', 'mark_number']);
+        });
+
+        // BOM Items - Links parts to raw materials
+        Schema::create('bom_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('fab_part_id')->constrained('fab_parts')->cascadeOnDelete();
+            $table->foreignId('raw_material_id')->constrained('raw_materials')->restrictOnDelete();
+            $table->integer('quantity_required')->default(1);
+            $table->decimal('cut_length', 12, 4)->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index('fab_part_id');
+            $table->index('raw_material_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bom_items');
+        Schema::dropIfExists('fab_parts');
+        Schema::dropIfExists('raw_materials');
+        Schema::dropIfExists('fab_jobs');
+    }
+};

--- a/database/seeders/FilamentMrpSeeder.php
+++ b/database/seeders/FilamentMrpSeeder.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\JobStatus;
+use App\Enums\MaterialType;
+use App\Enums\PartStatus;
+use App\Models\BomItem;
+use App\Models\FabJob;
+use App\Models\FabPart;
+use App\Models\RawMaterial;
+use Illuminate\Database\Seeder;
+
+class FilamentMrpSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Create Raw Materials
+        $materials = [
+            ['type' => MaterialType::Beam, 'size' => 'W10x26', 'grade' => 'A992', 'length' => 40, 'qty' => 25, 'location' => 'Bay A-1'],
+            ['type' => MaterialType::Beam, 'size' => 'W12x40', 'grade' => 'A992', 'length' => 40, 'qty' => 18, 'location' => 'Bay A-2'],
+            ['type' => MaterialType::Beam, 'size' => 'W14x22', 'grade' => 'A992', 'length' => 40, 'qty' => 12, 'location' => 'Bay A-3'],
+            ['type' => MaterialType::Beam, 'size' => 'W16x31', 'grade' => 'A992', 'length' => 40, 'qty' => 3, 'location' => 'Bay A-4'], // Low stock
+            ['type' => MaterialType::Channel, 'size' => 'C8x11.5', 'grade' => 'A36', 'length' => 20, 'qty' => 30, 'location' => 'Bay B-1'],
+            ['type' => MaterialType::Channel, 'size' => 'C10x15.3', 'grade' => 'A36', 'length' => 20, 'qty' => 2, 'location' => 'Bay B-2'], // Low stock
+            ['type' => MaterialType::Angle, 'size' => 'L4x4x1/4', 'grade' => 'A36', 'length' => 20, 'qty' => 50, 'location' => 'Bay C-1'],
+            ['type' => MaterialType::Angle, 'size' => 'L5x5x3/8', 'grade' => 'A36', 'length' => 20, 'qty' => 35, 'location' => 'Bay C-2'],
+            ['type' => MaterialType::Tube, 'size' => 'HSS6x6x1/4', 'grade' => 'A500B', 'length' => 24, 'qty' => 15, 'location' => 'Bay D-1'],
+            ['type' => MaterialType::Tube, 'size' => 'HSS8x8x3/8', 'grade' => 'A500B', 'length' => 24, 'qty' => 8, 'location' => 'Bay D-2'],
+            ['type' => MaterialType::Plate, 'size' => 'PL1/2x48', 'grade' => 'A36', 'length' => 96, 'qty' => 0, 'location' => 'Bay E-1'], // Out of stock
+            ['type' => MaterialType::Plate, 'size' => 'PL3/4x48', 'grade' => 'A572-50', 'length' => 96, 'qty' => 10, 'location' => 'Bay E-2'],
+            ['type' => MaterialType::Pipe, 'size' => 'PIPE4STD', 'grade' => 'A53B', 'length' => 21, 'qty' => 20, 'location' => 'Bay F-1'],
+            ['type' => MaterialType::Bar, 'size' => '1x4 FB', 'grade' => 'A36', 'length' => 20, 'qty' => 100, 'location' => 'Bay G-1'],
+        ];
+
+        $materialRecords = [];
+        foreach ($materials as $mat) {
+            $materialRecords[$mat['size']] = RawMaterial::create([
+                'material_type' => $mat['type'],
+                'size_description' => $mat['size'],
+                'grade' => $mat['grade'],
+                'length_stock' => $mat['length'],
+                'quantity_on_hand' => $mat['qty'],
+                'location' => $mat['location'],
+            ]);
+        }
+
+        // Create Jobs with various statuses
+        $jobs = [
+            [
+                'job_number' => 'FAB-2024-001',
+                'customer_name' => 'ACME Construction Corp',
+                'description' => 'Downtown Office Building - Steel Frame Package',
+                'status' => JobStatus::InProgress,
+                'due_date' => now()->addDays(30),
+            ],
+            [
+                'job_number' => 'FAB-2024-002',
+                'customer_name' => 'Bridge Builders Inc',
+                'description' => 'River Crossing Bridge Deck Supports',
+                'status' => JobStatus::Awarded,
+                'due_date' => now()->addDays(60),
+            ],
+            [
+                'job_number' => 'FAB-2024-003',
+                'customer_name' => 'Metro Steel Erectors',
+                'description' => 'Parking Garage Level 1 Columns and Beams',
+                'status' => JobStatus::Shipping,
+                'due_date' => now()->addDays(5),
+            ],
+            [
+                'job_number' => 'FAB-2024-004',
+                'customer_name' => 'Industrial Fabricators LLC',
+                'description' => 'Conveyor Support Structure',
+                'status' => JobStatus::Estimating,
+                'due_date' => now()->addDays(90),
+            ],
+            [
+                'job_number' => 'FAB-2024-005',
+                'customer_name' => 'Summit Steel Works',
+                'description' => 'Warehouse Mezzanine Platform',
+                'status' => JobStatus::Complete,
+                'due_date' => now()->subDays(5),
+            ],
+            [
+                'job_number' => 'FAB-2024-006',
+                'customer_name' => 'Pacific Construction Group',
+                'description' => 'Retail Building Canopy Frames',
+                'status' => JobStatus::Hold,
+                'due_date' => now()->addDays(45),
+            ],
+        ];
+
+        foreach ($jobs as $jobData) {
+            $job = FabJob::create($jobData);
+
+            // Create parts for each job
+            $this->createPartsForJob($job, $materialRecords);
+        }
+
+        $this->command->info('Filament MRP sample data seeded successfully!');
+    }
+
+    private function createPartsForJob(FabJob $job, array $materials): void
+    {
+        $partsData = match ($job->status) {
+            JobStatus::InProgress => [
+                ['mark' => 'B1', 'desc' => 'Main Beam - Grid A', 'qty' => 4, 'grade' => 'A992', 'weight' => 520, 'status' => PartStatus::Fabrication, 'material' => 'W12x40'],
+                ['mark' => 'B2', 'desc' => 'Secondary Beam', 'qty' => 8, 'grade' => 'A992', 'weight' => 260, 'status' => PartStatus::Cutting, 'material' => 'W10x26'],
+                ['mark' => 'C1', 'desc' => 'Column - Interior', 'qty' => 6, 'grade' => 'A992', 'weight' => 440, 'status' => PartStatus::Pending, 'material' => 'W14x22'],
+                ['mark' => 'BR1', 'desc' => 'Diagonal Brace', 'qty' => 12, 'grade' => 'A500B', 'weight' => 95, 'status' => PartStatus::Nested, 'material' => 'HSS6x6x1/4'],
+            ],
+            JobStatus::Awarded => [
+                ['mark' => 'GB1', 'desc' => 'Girder - Span 1', 'qty' => 2, 'grade' => 'A992', 'weight' => 1240, 'status' => PartStatus::Pending, 'material' => 'W16x31'],
+                ['mark' => 'GB2', 'desc' => 'Girder - Span 2', 'qty' => 2, 'grade' => 'A992', 'weight' => 1240, 'status' => PartStatus::Pending, 'material' => 'W16x31'],
+                ['mark' => 'STF1', 'desc' => 'Stiffener Plate', 'qty' => 16, 'grade' => 'A572-50', 'weight' => 45, 'status' => PartStatus::Pending, 'material' => 'PL3/4x48'],
+            ],
+            JobStatus::Shipping => [
+                ['mark' => 'PC1', 'desc' => 'Parking Column', 'qty' => 10, 'grade' => 'A992', 'weight' => 380, 'status' => PartStatus::Complete, 'material' => 'W12x40'],
+                ['mark' => 'PB1', 'desc' => 'Parking Beam', 'qty' => 20, 'grade' => 'A992', 'weight' => 520, 'status' => PartStatus::Complete, 'material' => 'W10x26'],
+                ['mark' => 'PB2', 'desc' => 'Edge Beam', 'qty' => 8, 'grade' => 'A36', 'weight' => 230, 'status' => PartStatus::Shipped, 'material' => 'C10x15.3'],
+            ],
+            JobStatus::Complete => [
+                ['mark' => 'M1', 'desc' => 'Mezzanine Column', 'qty' => 8, 'grade' => 'A500B', 'weight' => 180, 'status' => PartStatus::Shipped, 'material' => 'HSS8x8x3/8'],
+                ['mark' => 'M2', 'desc' => 'Mezzanine Beam', 'qty' => 12, 'grade' => 'A992', 'weight' => 260, 'status' => PartStatus::Shipped, 'material' => 'W10x26'],
+            ],
+            default => [
+                ['mark' => 'P1', 'desc' => 'Generic Part 1', 'qty' => 4, 'grade' => 'A36', 'weight' => 150, 'status' => PartStatus::Pending, 'material' => 'L4x4x1/4'],
+                ['mark' => 'P2', 'desc' => 'Generic Part 2', 'qty' => 6, 'grade' => 'A36', 'weight' => 85, 'status' => PartStatus::Pending, 'material' => 'C8x11.5'],
+            ],
+        };
+
+        foreach ($partsData as $partData) {
+            $part = FabPart::create([
+                'fab_job_id' => $job->id,
+                'mark_number' => $partData['mark'],
+                'description' => $partData['desc'],
+                'quantity' => $partData['qty'],
+                'material_grade' => $partData['grade'],
+                'weight_each' => $partData['weight'],
+                'status' => $partData['status'],
+            ]);
+
+            // Create BOM item linking to material
+            if (isset($materials[$partData['material']])) {
+                BomItem::create([
+                    'fab_part_id' => $part->id,
+                    'raw_material_id' => $materials[$partData['material']]->id,
+                    'quantity_required' => $partData['qty'],
+                    'cut_length' => rand(8, 20) + (rand(0, 100) / 100),
+                    'notes' => null,
+                ]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Create PHP enums: JobStatus, PartStatus, MaterialType with Filament badges
- Add migration for fab_jobs, fab_parts, raw_materials, bom_items tables
- Create Eloquent models with relationships and computed attributes
- Build FabJobResource with filters, CSV export, Parts relation manager
- Build FabPartResource with bulk status updates, nested BOM repeater
- Build RawMaterialResource with low stock alerts, inventory adjustment
- Build BomItemResource linking parts to raw materials
- Add dashboard widgets: JobsStatusChart, PendingPartsStats, LowStockAlert
- Include FilamentMrpSeeder with realistic sample data
- Fix Filament 4 type compatibility for navigation properties