### PR TITLE
Fix Vite build with Tailwind v4 and Filament theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@headlessui/vue": "^1.7.19",
                 "@inertiajs/vue3": "^1.0.16",
                 "@tailwindcss/forms": "^0.5.7",
+                "@tailwindcss/postcss": "^4.0.0",
                 "@vitejs/plugin-vue": "^5.0.4",
                 "autoprefixer": "^10.4.18",
                 "axios": "^1.6.7",
@@ -23,7 +24,7 @@
                 "eslint-plugin-vue": "^9.23.0",
                 "laravel-vite-plugin": "^1.0.2",
                 "postcss": "^8.4.35",
-                "tailwindcss": "^3.4.1",
+                "tailwindcss": "^4.0.0",
                 "vite": "^6.0.0",
                 "vue": "^3.4.21"
             }
@@ -694,6 +695,17 @@
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1080,6 +1092,277 @@
                 "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
             }
         },
+        "node_modules/@tailwindcss/node": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
+            "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.4",
+                "enhanced-resolve": "^5.18.3",
+                "jiti": "^2.6.1",
+                "lightningcss": "1.30.2",
+                "magic-string": "^0.30.21",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.1.18"
+            }
+        },
+        "node_modules/@tailwindcss/oxide": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
+            "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@tailwindcss/oxide-android-arm64": "4.1.18",
+                "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+                "@tailwindcss/oxide-darwin-x64": "4.1.18",
+                "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+                "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+                "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-android-arm64": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+            "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-arm64": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
+            "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-x64": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+            "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-freebsd-x64": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+            "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+            "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+            "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+            "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+            "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+            "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+            "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@emnapi/wasi-threads": "^1.1.0",
+                "@napi-rs/wasm-runtime": "^1.1.0",
+                "@tybys/wasm-util": "^0.10.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+            "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+            "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/postcss": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
+            "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@alloc/quick-lru": "^5.2.0",
+                "@tailwindcss/node": "4.1.18",
+                "@tailwindcss/oxide": "4.1.18",
+                "postcss": "^8.4.41",
+                "tailwindcss": "4.1.18"
+            }
+        },
         "node_modules/@tanstack/virtual-core": {
             "version": "3.13.14",
             "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.14.tgz",
@@ -1308,34 +1591,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/any-promise": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/anymatch": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/arg": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1416,19 +1671,6 @@
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
-        "node_modules/binary-extensions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1445,19 +1687,6 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/browserslist": {
@@ -1535,16 +1764,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelcase-css": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-            "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001762",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
@@ -1583,44 +1802,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/chokidar/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1652,16 +1833,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/commander": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/concat-map": {
@@ -1750,19 +1921,15 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/didyoumean": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/dlv": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true,
-            "license": "MIT"
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -1798,6 +1965,20 @@
             "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.18.4",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
         },
         "node_modules/entities": {
             "version": "7.0.0",
@@ -2112,36 +2293,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2177,19 +2328,6 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -2418,6 +2556,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2533,35 +2678,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2585,16 +2701,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2613,13 +2719,13 @@
             "license": "ISC"
         },
         "node_modules/jiti": {
-            "version": "1.21.7",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
-                "jiti": "bin/jiti.js"
+                "jiti": "lib/jiti-cli.mjs"
             }
         },
         "node_modules/js-yaml": {
@@ -2700,25 +2806,266 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/lilconfig": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+        "node_modules/lightningcss": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+            "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
             "dev": true,
-            "license": "MIT",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
             "engines": {
-                "node": ">=14"
+                "node": ">= 12.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/antonk52"
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.30.2",
+                "lightningcss-darwin-arm64": "1.30.2",
+                "lightningcss-darwin-x64": "1.30.2",
+                "lightningcss-freebsd-x64": "1.30.2",
+                "lightningcss-linux-arm-gnueabihf": "1.30.2",
+                "lightningcss-linux-arm64-gnu": "1.30.2",
+                "lightningcss-linux-arm64-musl": "1.30.2",
+                "lightningcss-linux-x64-gnu": "1.30.2",
+                "lightningcss-linux-x64-musl": "1.30.2",
+                "lightningcss-win32-arm64-msvc": "1.30.2",
+                "lightningcss-win32-x64-msvc": "1.30.2"
             }
         },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+            "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "license": "MIT"
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+            "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+            "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+            "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+            "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+            "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+            "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+            "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+            "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+            "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.2",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+            "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -2784,30 +3131,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2861,18 +3184,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/mz": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "any-promise": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "thenify-all": "^1.0.0"
-            }
-        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2905,16 +3216,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/nprogress": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
@@ -2933,26 +3234,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-hash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/object-inspect": {
@@ -3071,13 +3352,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3095,16 +3369,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/pinia": {
@@ -3127,16 +3391,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/pirates": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/postcss": {
@@ -3165,119 +3419,6 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
-            }
-        },
-        "node_modules/postcss-import": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "postcss-value-parser": "^4.0.0",
-                "read-cache": "^1.0.0",
-                "resolve": "^1.1.7"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.0.0"
-            }
-        },
-        "node_modules/postcss-js": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-            "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "camelcase-css": "^2.0.1"
-            },
-            "engines": {
-                "node": "^12 || ^14 || >= 16"
-            },
-            "peerDependencies": {
-                "postcss": "^8.4.21"
-            }
-        },
-        "node_modules/postcss-load-config": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-            "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "lilconfig": "^3.1.1"
-            },
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "jiti": ">=1.21.0",
-                "postcss": ">=8.0.9",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "jiti": {
-                    "optional": true
-                },
-                "postcss": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/postcss-nested": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-            "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "postcss-selector-parser": "^6.1.1"
-            },
-            "engines": {
-                "node": ">=12.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.2.14"
             }
         },
         "node_modules/postcss-selector-parser": {
@@ -3376,50 +3517,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/read-cache": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-            "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pify": "^2.3.0"
-            }
-        },
-        "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -3672,29 +3769,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/sucrase": {
-            "version": "3.35.1",
-            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "commander": "^4.0.0",
-                "lines-and-columns": "^1.1.6",
-                "mz": "^2.7.0",
-                "pirates": "^4.0.1",
-                "tinyglobby": "^0.2.11",
-                "ts-interface-checker": "^0.1.9"
-            },
-            "bin": {
-                "sucrase": "bin/sucrase",
-                "sucrase-node": "bin/sucrase-node"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3708,55 +3782,25 @@
                 "node": ">=8"
             }
         },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+        "node_modules/tailwindcss": {
+            "version": "4.1.18",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
+            "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tapable": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.4"
+                "node": ">=6"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/tailwindcss": {
-            "version": "3.4.19",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-            "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@alloc/quick-lru": "^5.2.0",
-                "arg": "^5.0.2",
-                "chokidar": "^3.6.0",
-                "didyoumean": "^1.2.2",
-                "dlv": "^1.1.3",
-                "fast-glob": "^3.3.2",
-                "glob-parent": "^6.0.2",
-                "is-glob": "^4.0.3",
-                "jiti": "^1.21.7",
-                "lilconfig": "^3.1.3",
-                "micromatch": "^4.0.8",
-                "normalize-path": "^3.0.0",
-                "object-hash": "^3.0.0",
-                "picocolors": "^1.1.1",
-                "postcss": "^8.4.47",
-                "postcss-import": "^15.1.0",
-                "postcss-js": "^4.0.1",
-                "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-                "postcss-nested": "^6.2.0",
-                "postcss-selector-parser": "^6.1.2",
-                "resolve": "^1.22.8",
-                "sucrase": "^3.35.0"
-            },
-            "bin": {
-                "tailwind": "lib/cli.js",
-                "tailwindcss": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/text-table": {
@@ -3765,29 +3809,6 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/thenify": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "any-promise": "^1.0.0"
-            }
-        },
-        "node_modules/thenify-all": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "thenify": ">= 3.1.0 < 4"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
@@ -3836,26 +3857,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
-        },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/ts-interface-checker": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-            "dev": true,
-            "license": "Apache-2.0"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@headlessui/vue": "^1.7.19",
         "@inertiajs/vue3": "^1.0.16",
         "@tailwindcss/forms": "^0.5.7",
+        "@tailwindcss/postcss": "^4.0.0",
         "@vitejs/plugin-vue": "^5.0.4",
         "autoprefixer": "^10.4.18",
         "axios": "^1.6.7",
@@ -23,7 +24,7 @@
         "eslint-plugin-vue": "^9.23.0",
         "laravel-vite-plugin": "^1.0.2",
         "postcss": "^8.4.35",
-        "tailwindcss": "^3.4.1",
+        "tailwindcss": "^4.0.0",
         "vite": "^6.0.0",
         "vue": "^3.4.21"
     },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
     plugins: {
-        tailwindcss: {},
+        '@tailwindcss/postcss': {},
         autoprefixer: {},
     },
 };

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,12 +1,14 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import 'tailwindcss';
+
+@config '../../tailwind.config.js';
 
 @layer base {
   /* Industrial Base Styles */
   body {
     @apply bg-steel-950 text-steel-300 font-sans antialiased;
-    @apply bg-texture-grid bg-grid;
+    background-image: linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+    background-size: 20px 20px;
   }
 
   /* All numbers should be tabular */
@@ -37,7 +39,13 @@
   }
 
   .btn-primary {
-    @apply btn bg-forge-600 text-white border-none;
+    @apply inline-flex items-center justify-center gap-2;
+    @apply px-6 py-3 rounded-industrial;
+    @apply font-semibold text-sm uppercase tracking-industrial;
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-steel-950;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-forge-600 text-white border-none;
     @apply hover:bg-forge-700 hover:-translate-y-0.5;
     @apply active:bg-forge-800 active:translate-y-0;
     @apply shadow-glow-forge hover:shadow-glow-forge-lg;
@@ -45,27 +53,51 @@
   }
 
   .btn-secondary {
-    @apply btn bg-steel-700 text-steel-300;
+    @apply inline-flex items-center justify-center gap-2;
+    @apply px-6 py-3 rounded-industrial;
+    @apply font-semibold text-sm uppercase tracking-industrial;
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-steel-950;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-steel-700 text-steel-300;
     @apply border border-steel-600;
     @apply hover:bg-steel-600 hover:text-steel-200;
     @apply focus:ring-weld-500;
   }
 
   .btn-ghost {
-    @apply btn bg-transparent text-steel-400;
+    @apply inline-flex items-center justify-center gap-2;
+    @apply px-6 py-3 rounded-industrial;
+    @apply font-semibold text-sm uppercase tracking-industrial;
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-steel-950;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-transparent text-steel-400;
     @apply hover:bg-steel-800 hover:text-steel-300;
     @apply focus:ring-steel-600;
   }
 
   .btn-danger {
-    @apply btn bg-red-600 text-white;
+    @apply inline-flex items-center justify-center gap-2;
+    @apply px-6 py-3 rounded-industrial;
+    @apply font-semibold text-sm uppercase tracking-industrial;
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-steel-950;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-red-600 text-white;
     @apply hover:bg-red-700;
     @apply shadow-[0_0_20px_rgba(239,68,68,0.25)];
     @apply focus:ring-red-500;
   }
 
   .btn-weld {
-    @apply btn bg-weld-600 text-white;
+    @apply inline-flex items-center justify-center gap-2;
+    @apply px-6 py-3 rounded-industrial;
+    @apply font-semibold text-sm uppercase tracking-industrial;
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-steel-950;
+    @apply disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-weld-600 text-white;
     @apply hover:bg-weld-700;
     @apply shadow-glow-weld hover:shadow-glow-weld-lg;
     @apply focus:ring-weld-500;
@@ -88,7 +120,10 @@
   }
 
   .card-glow {
-    @apply card-elevated;
+    @apply bg-steel-800 rounded-industrial;
+    @apply border border-steel-600;
+    @apply shadow-industrial-lg;
+    @apply p-6;
     @apply shadow-industrial-xl;
     @apply hover:shadow-glow-forge transition-shadow duration-300;
   }
@@ -96,7 +131,11 @@
   /* === METRIC CARDS === */
   
   .metric-card {
-    @apply card-elevated relative overflow-hidden;
+    @apply bg-steel-800 rounded-industrial;
+    @apply border border-steel-600;
+    @apply shadow-industrial-lg;
+    @apply p-6;
+    @apply relative overflow-hidden;
     @apply min-h-[180px] flex flex-col justify-between;
   }
 
@@ -125,11 +164,13 @@
   }
 
   .metric-trend-up {
-    @apply metric-trend text-green-400;
+    @apply text-sm font-medium mt-2;
+    @apply text-green-400;
   }
 
   .metric-trend-down {
-    @apply metric-trend text-red-400;
+    @apply text-sm font-medium mt-2;
+    @apply text-red-400;
   }
 
   /* === STATUS BADGES === */
@@ -142,31 +183,49 @@
   }
 
   .badge-free {
-    @apply badge bg-green-500/15 border-green-500 text-green-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-green-500/15 border-green-500 text-green-400;
     @apply shadow-[0_0_8px_rgba(16,185,129,0.3)];
   }
 
   .badge-assigned {
-    @apply badge bg-blue-500/15 border-blue-500 text-blue-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-blue-500/15 border-blue-500 text-blue-400;
     @apply shadow-[0_0_8px_rgba(59,130,246,0.3)];
   }
 
   .badge-in-progress {
-    @apply badge bg-orange-500/15 border-forge-500 text-forge-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-orange-500/15 border-forge-500 text-forge-400;
     @apply shadow-glow-forge animate-pulse-glow;
   }
 
   .badge-complete {
-    @apply badge bg-green-500/15 border-green-500 text-green-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-green-500/15 border-green-500 text-green-400;
   }
 
   .badge-warning {
-    @apply badge bg-safety-500/15 border-safety-400 text-safety-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-safety-500/15 border-safety-400 text-safety-400;
     @apply animate-pulse-glow;
   }
 
   .badge-error {
-    @apply badge bg-red-500/15 border-red-500 text-red-400;
+    @apply inline-flex items-center gap-1.5;
+    @apply px-3 py-1.5 rounded-industrial;
+    @apply text-xs font-bold uppercase tracking-wide;
+    @apply border bg-red-500/15 border-red-500 text-red-400;
   }
 
   /* === FORM INPUTS === */
@@ -183,17 +242,39 @@
   }
 
   .input-error {
-    @apply input border-red-500;
-    @apply focus:border-red-500 focus:ring-red-500/20;
+    @apply w-full px-4 py-2.5 rounded-industrial;
+    @apply bg-steel-850 border border-red-500;
+    @apply text-steel-300 placeholder-steel-500;
+    @apply shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)];
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:border-red-500;
+    @apply focus:ring-2 focus:ring-red-500/20;
+    @apply focus:shadow-glow-weld;
   }
 
   .select {
-    @apply input cursor-pointer;
+    @apply w-full px-4 py-2.5 rounded-industrial;
+    @apply bg-steel-850 border border-steel-700;
+    @apply text-steel-300 placeholder-steel-500;
+    @apply shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)];
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:border-weld-500;
+    @apply focus:ring-2 focus:ring-weld-500/20;
+    @apply focus:shadow-glow-weld;
+    @apply cursor-pointer;
     @apply bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEyIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTEgMUw2IDZMMTEgMSIgc3Ryb2tlPSIjNzE3MTdhIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==')] bg-[right_1rem_center] bg-no-repeat pr-10;
   }
 
   .textarea {
-    @apply input resize-y min-h-[100px];
+    @apply w-full px-4 py-2.5 rounded-industrial;
+    @apply bg-steel-850 border border-steel-700;
+    @apply text-steel-300 placeholder-steel-500;
+    @apply shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)];
+    @apply transition-all duration-200;
+    @apply focus:outline-none focus:border-weld-500;
+    @apply focus:ring-2 focus:ring-weld-500/20;
+    @apply focus:shadow-glow-weld;
+    @apply resize-y min-h-[100px];
   }
 
   .checkbox {
@@ -203,7 +284,10 @@
   }
 
   .radio {
-    @apply checkbox rounded-full;
+    @apply w-5 h-5 rounded border-steel-600 bg-steel-800;
+    @apply text-forge-600 focus:ring-forge-500 focus:ring-offset-steel-950;
+    @apply cursor-pointer;
+    @apply rounded-full;
   }
 
   /* === TABLES === */
@@ -270,7 +354,11 @@
   }
 
   .nav-link-active {
-    @apply nav-link text-forge-500;
+    @apply px-4 py-2 text-sm font-semibold uppercase tracking-industrial;
+    @apply text-steel-400 transition-all duration-200;
+    @apply hover:text-steel-300;
+    @apply relative;
+    @apply text-forge-500;
   }
 
   .nav-link-active::after {
@@ -303,7 +391,8 @@
   }
 
   .divider-glow {
-    @apply divider border-forge-600/30;
+    @apply border-t border-steel-700 my-6;
+    @apply border-forge-600/30;
     box-shadow: 0 1px 3px rgba(255, 107, 53, 0.2);
   }
 
@@ -362,19 +451,23 @@
   }
 
   .alert-info {
-    @apply alert bg-weld-500/10 border-weld-500 text-weld-400;
+    @apply flex items-start gap-3 p-4 rounded-industrial border;
+    @apply bg-weld-500/10 border-weld-500 text-weld-400;
   }
 
   .alert-warning {
-    @apply alert bg-safety-500/10 border-safety-500 text-safety-400;
+    @apply flex items-start gap-3 p-4 rounded-industrial border;
+    @apply bg-safety-500/10 border-safety-500 text-safety-400;
   }
 
   .alert-error {
-    @apply alert bg-red-500/10 border-red-500 text-red-400;
+    @apply flex items-start gap-3 p-4 rounded-industrial border;
+    @apply bg-red-500/10 border-red-500 text-red-400;
   }
 
   .alert-success {
-    @apply alert bg-green-500/10 border-green-500 text-green-400;
+    @apply flex items-start gap-3 p-4 rounded-industrial border;
+    @apply bg-green-500/10 border-green-500 text-green-400;
   }
 
   /* === UTILITY CLASSES === */
@@ -414,11 +507,27 @@
   }
 
   .brushed-steel {
-    @apply bg-texture-brushed;
+    background-image: repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 2px,
+      rgba(255, 255, 255, 0.02) 2px,
+      rgba(255, 255, 255, 0.02) 4px
+    );
   }
 
   .diamond-plate {
-    @apply bg-texture-diamond bg-diamond;
+    background-image: radial-gradient(
+        circle at 25% 25%,
+        rgba(255, 255, 255, 0.03) 2%,
+        transparent 0%
+      ),
+      radial-gradient(
+        circle at 75% 75%,
+        rgba(255, 255, 255, 0.03) 2%,
+        transparent 0%
+      );
+    background-size: 16px 16px;
   }
 }
 

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1,5 +1,5 @@
-@import '/vendor/filament/filament/resources/css/theme.css';
+@import '../../../../vendor/filament/filament/resources/css/theme.css';
 
-@config 'tailwind.config.js';
+@config '../../../../tailwind.config.js';
 
 /* Custom theme for SteelFlow MRP Admin Panel */


### PR DESCRIPTION
### Motivation

- Vite builds were failing due to Filament theme imports and Tailwind/PostCSS pipeline incompatibilities with the project's CSS usage. 
- Filament's shipped theme and some project styles expect Tailwind v4 processing and a different PostCSS entry, causing missing-file and `@apply` errors. 
- Tailwind v4 also disallows certain `@apply` uses for custom component classes, which broke CSS compilation. 

### Description

- Bumped Tailwind toolchain and added the PostCSS adapter by updating `package.json` and `package-lock.json` to include `tailwindcss@^4.0.0` and `@tailwindcss/postcss`. 
- Switched `postcss.config.js` to use the v4-compatible `@tailwindcss/postcss` plugin so PostCSS/Tailwind integration works during Vite builds. 
- Adjusted CSS imports and config resolution by changing `resources/css/app.css` to `@import 'tailwindcss'` and adding `@config '../../tailwind.config.js'`, and by fixing the Filament theme import and config path in `resources/css/filament/admin/theme.css`. 
- Inlined base utilities for components (buttons, cards, badges, inputs and background textures) inside `resources/css/app.css` to avoid unsupported `@apply` of custom classes under Tailwind v4. 

### Testing

- Ran `npm run build` in the CI/dev environment and Vite completed a production build producing assets under `public/build` (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a4ba506c83249f3a846c0e375e4c)