### PR TITLE
Create import template exports for demonstrations

### DIFF
--- a/app/Http/Controllers/ImportTemplateController.php
+++ b/app/Http/Controllers/ImportTemplateController.php
@@ -1,0 +1,67 @@
+<?php
+
+// app/Http/Controllers/ImportTemplateController.php
+
+namespace App\Http\Controllers;
+
+use App\Services\Import\ImportTemplateService;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImportTemplateController extends Controller
+{
+    public function __construct(
+        protected ImportTemplateService $templateService
+    ) {}
+
+    /**
+     * Display list of all available import templates.
+     */
+    public function index(): Response
+    {
+        return Inertia::render('ImportTemplates/Index', [
+            'templates' => $this->templateService->getAvailableTemplates(),
+        ]);
+    }
+
+    /**
+     * Download a specific import template.
+     */
+    public function download(string $type): StreamedResponse
+    {
+        return $this->templateService->download($type);
+    }
+
+    /**
+     * Download customers import template.
+     */
+    public function customers(): StreamedResponse
+    {
+        return $this->templateService->download(ImportTemplateService::TEMPLATE_CUSTOMERS);
+    }
+
+    /**
+     * Download KISS format import template.
+     */
+    public function kiss(): StreamedResponse
+    {
+        return $this->templateService->download(ImportTemplateService::TEMPLATE_KISS);
+    }
+
+    /**
+     * Download XSR format import template.
+     */
+    public function xsr(): StreamedResponse
+    {
+        return $this->templateService->download(ImportTemplateService::TEMPLATE_XSR);
+    }
+
+    /**
+     * Download UPF material catalog import template.
+     */
+    public function upf(): StreamedResponse
+    {
+        return $this->templateService->download(ImportTemplateService::TEMPLATE_UPF);
+    }
+}

--- a/app/Services/Import/ImportTemplateService.php
+++ b/app/Services/Import/ImportTemplateService.php
@@ -1,0 +1,219 @@
+<?php
+
+// app/Services/Import/ImportTemplateService.php
+
+namespace App\Services\Import;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImportTemplateService
+{
+    /**
+     * Available import template types
+     */
+    public const TEMPLATE_CUSTOMERS = 'customers';
+    public const TEMPLATE_KISS = 'kiss';
+    public const TEMPLATE_XSR = 'xsr';
+    public const TEMPLATE_UPF = 'upf';
+
+    /**
+     * Get template metadata for all available templates
+     */
+    public function getAvailableTemplates(): array
+    {
+        return [
+            self::TEMPLATE_CUSTOMERS => [
+                'name' => 'Customers',
+                'description' => 'Import customer records with contact information',
+                'filename' => 'customers_import_template.csv',
+            ],
+            self::TEMPLATE_KISS => [
+                'name' => 'KISS Format (BOM)',
+                'description' => 'Import assemblies and parts from KISS CAD format',
+                'filename' => 'kiss_import_template.csv',
+            ],
+            self::TEMPLATE_XSR => [
+                'name' => 'XSR Format (BOM)',
+                'description' => 'Import parts from XSR CAD format',
+                'filename' => 'xsr_import_template.csv',
+            ],
+            self::TEMPLATE_UPF => [
+                'name' => 'UPF Material Catalog',
+                'description' => 'Import material types, grades, and pricing from FabTrol UPF format',
+                'filename' => 'upf_material_catalog_template.csv',
+            ],
+        ];
+    }
+
+    /**
+     * Generate a streamed CSV response for the given template type
+     */
+    public function download(string $templateType): StreamedResponse
+    {
+        $templates = $this->getAvailableTemplates();
+
+        if (! isset($templates[$templateType])) {
+            abort(404, 'Template not found');
+        }
+
+        $template = $templates[$templateType];
+        $content = $this->generateTemplateContent($templateType);
+
+        return response()->streamDownload(
+            function () use ($content): void {
+                echo $content;
+            },
+            $template['filename'],
+            [
+                'Content-Type' => 'text/csv',
+                'Content-Disposition' => 'attachment; filename="' . $template['filename'] . '"',
+            ]
+        );
+    }
+
+    /**
+     * Generate the CSV content for a template type
+     */
+    protected function generateTemplateContent(string $templateType): string
+    {
+        return match ($templateType) {
+            self::TEMPLATE_CUSTOMERS => $this->generateCustomersTemplate(),
+            self::TEMPLATE_KISS => $this->generateKissTemplate(),
+            self::TEMPLATE_XSR => $this->generateXsrTemplate(),
+            self::TEMPLATE_UPF => $this->generateUpfTemplate(),
+            default => '',
+        };
+    }
+
+    /**
+     * Generate the Customers import template CSV
+     */
+    protected function generateCustomersTemplate(): string
+    {
+        $rows = [
+            // Header row
+            ['code', 'name', 'address_1', 'address_2', 'city', 'state', 'zip', 'country', 'phone', 'email', 'notes', 'is_active'],
+            // Example rows with sample data
+            ['CUST001', 'Acme Steel Corporation', '123 Industrial Blvd', 'Suite 100', 'Houston', 'TX', '77001', 'USA', '713-555-0100', 'orders@acmesteel.com', 'Primary steel supplier', 'true'],
+            ['CUST002', 'Metro Construction LLC', '456 Commerce Drive', '', 'Dallas', 'TX', '75201', 'USA', '214-555-0200', 'purchasing@metroconstruction.com', 'General contractor', 'true'],
+            ['CUST003', 'Pacific Fabricators Inc', '789 Harbor Way', 'Building B', 'Long Beach', 'CA', '90802', 'USA', '562-555-0300', 'info@pacificfab.com', 'West coast fabrication partner', 'true'],
+        ];
+
+        return $this->arrayToCsv($rows);
+    }
+
+    /**
+     * Generate the KISS format import template CSV
+     *
+     * KISS format uses two record types:
+     * - SHP: Assembly/shipping records
+     * - DET: Detail/part records
+     */
+    protected function generateKissTemplate(): string
+    {
+        $rows = [
+            // Assembly records (SHP type)
+            // Format: Type, Mark, Qty, Description, WeightEach, WeightTotal, Remark, Drawing
+            ['SHP', 'A1', '2', 'BEAM ASSEMBLY', '1250.5', '2501.0', 'Main beam', 'DWG-001'],
+            ['SHP', 'A2', '4', 'COLUMN ASSEMBLY', '850.0', '3400.0', 'Corner column', 'DWG-002'],
+            ['SHP', 'B1', '1', 'BRACE ASSEMBLY', '425.25', '425.25', 'Lateral brace', 'DWG-003'],
+
+            // Part records (DET type)
+            // Format: Type, AssemblyMark, PartMark, QtyEach, Description, Material, Size, Length, WeightEach, WeightTotal
+            ['DET', 'A1', 'P1', '2', 'MAIN BEAM', 'A36', 'W24X76', '20-0-0', '380.0', '760.0'],
+            ['DET', 'A1', 'P2', '4', 'STIFFENER PLATE', 'A36', 'PL1/2X6', '1-6-0', '15.3', '61.2'],
+            ['DET', 'A1', 'P3', '8', 'GUSSET PLATE', 'A572-50', 'PL3/8X8', '0-8-0', '8.5', '68.0'],
+            ['DET', 'A2', 'P4', '1', 'COLUMN', 'A992', 'W14X48', '15-0-0', '720.0', '720.0'],
+            ['DET', 'A2', 'P5', '2', 'BASE PLATE', 'A36', 'PL1X14', '1-2-0', '33.25', '66.5'],
+            ['DET', 'B1', 'P6', '2', 'BRACE MEMBER', 'A500-B', 'HSS6X6X3/8', '12-6-0', '187.5', '375.0'],
+            ['DET', 'B1', 'P7', '4', 'CONNECTION ANGLE', 'A36', 'L4X4X3/8', '0-6-0', '6.0', '24.0'],
+        ];
+
+        return $this->arrayToCsv($rows);
+    }
+
+    /**
+     * Generate the XSR format import template CSV
+     *
+     * XSR format uses header-based CSV with flexible column names
+     */
+    protected function generateXsrTemplate(): string
+    {
+        $rows = [
+            // Header row (supports alternate column names shown in comments)
+            ['AssemblyMark', 'PartMark', 'Quantity', 'Material', 'Shape', 'Length', 'Weight'],
+            // Alternate headers: Assembly, Mark, Qty, Grade, Size
+
+            // Example data rows
+            ['A1', 'P1', '2', 'A36', 'W24X76', '240', '380.0'],
+            ['A1', 'P2', '4', 'A36', 'PL1/2X6', '18', '15.3'],
+            ['A1', 'P3', '8', 'A572-50', 'PL3/8X8', '8', '8.5'],
+            ['A2', 'P4', '1', 'A992', 'W14X48', '180', '720.0'],
+            ['A2', 'P5', '2', 'A36', 'PL1X14', '14', '33.25'],
+            ['B1', 'P6', '2', 'A500-B', 'HSS6X6X3/8', '150', '187.5'],
+            ['B1', 'P7', '4', 'A36', 'L4X4X3/8', '6', '6.0'],
+            ['', 'P8', '10', 'A36', 'PL1/4X4', '12', '4.1'],  // Part without assembly (DETACHED)
+        ];
+
+        return $this->arrayToCsv($rows);
+    }
+
+    /**
+     * Generate the UPF Material Catalog import template CSV
+     *
+     * UPF format imports material types, grades, and pricing information
+     */
+    protected function generateUpfTemplate(): string
+    {
+        $rows = [
+            // Header row
+            ['TYPE', 'TYPEDESC', 'GRADE', 'SIZE', 'PRICE', 'PUNIT', 'THICK', 'WTFT', 'PKEY', 'FILEKEY', 'ORDERKEY'],
+            // Alternate headers: TYPE_NAME, DESCRIPTION, GRADE_NAME, UNIT_PRICE, UNIT, THICKNESS, WEIGHT_FT
+
+            // Wide Flange Beams
+            ['W', 'Wide Flange', 'A992', 'W24X76', '0.85', 'LB', '0.44', '76', '', '', ''],
+            ['W', 'Wide Flange', 'A992', 'W24X55', '0.85', 'LB', '0.395', '55', '', '', ''],
+            ['W', 'Wide Flange', 'A992', 'W14X48', '0.87', 'LB', '0.34', '48', '', '', ''],
+            ['W', 'Wide Flange', 'A992', 'W14X30', '0.87', 'LB', '0.27', '30', '', '', ''],
+            ['W', 'Wide Flange', 'A36', 'W12X26', '0.82', 'LB', '0.23', '26', '', '', ''],
+
+            // Channels
+            ['C', 'Channel', 'A36', 'C12X20.7', '0.90', 'LB', '0.282', '20.7', '', '', ''],
+            ['C', 'Channel', 'A36', 'C10X15.3', '0.90', 'LB', '0.24', '15.3', '', '', ''],
+
+            // Angles
+            ['L', 'Angle', 'A36', 'L4X4X3/8', '0.88', 'LB', '0.375', '9.8', '', '', ''],
+            ['L', 'Angle', 'A36', 'L3X3X1/4', '0.88', 'LB', '0.25', '4.9', '', '', ''],
+
+            // HSS (Hollow Structural Sections)
+            ['HSS', 'HSS Tube/Pipe', 'A500-B', 'HSS6X6X3/8', '1.05', 'LB', '0.375', '27.48', '', '', ''],
+            ['HSS', 'HSS Tube/Pipe', 'A500-B', 'HSS4X4X1/4', '1.05', 'LB', '0.25', '12.21', '', '', ''],
+
+            // Plates
+            ['PL', 'Plate', 'A36', 'PL1/4X48', '0.75', 'LB', '0.25', '10.2', '', '', ''],
+            ['PL', 'Plate', 'A36', 'PL3/8X48', '0.75', 'LB', '0.375', '15.3', '', '', ''],
+            ['PL', 'Plate', 'A36', 'PL1/2X48', '0.75', 'LB', '0.5', '20.4', '', '', ''],
+            ['PL', 'Plate', 'A572-50', 'PL1X48', '0.78', 'LB', '1.0', '40.8', '', '', ''],
+        ];
+
+        return $this->arrayToCsv($rows);
+    }
+
+    /**
+     * Convert array of rows to CSV string
+     */
+    protected function arrayToCsv(array $rows): string
+    {
+        $output = fopen('php://temp', 'r+');
+
+        foreach ($rows as $row) {
+            fputcsv($output, $row);
+        }
+
+        rewind($output);
+        $csv = stream_get_contents($output);
+        fclose($output);
+
+        return $csv;
+    }
+}

--- a/resources/js/Pages/Customers/Import.vue
+++ b/resources/js/Pages/Customers/Import.vue
@@ -56,6 +56,14 @@ const submit = () => {
           Expected headers: code, name, address_1, address_2, city, state, zip, country, phone, email, notes, is_active.
           Rows with missing names will be skipped politely.
         </p>
+        <p class="mt-2">
+          <a
+            :href="route('import-templates.customers')"
+            class="text-sm text-forge-400 hover:text-forge-300 font-mono underline"
+          >
+            Download Template CSV
+          </a>
+        </p>
       </div>
 
       <div class="flex justify-end space-x-3">

--- a/resources/js/Pages/ImportTemplates/Index.vue
+++ b/resources/js/Pages/ImportTemplates/Index.vue
@@ -1,0 +1,137 @@
+<!-- resources/js/Pages/ImportTemplates/Index.vue -->
+<script setup>
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head } from '@inertiajs/vue3';
+
+defineProps({
+    templates: Object,
+});
+
+const templateDetails = {
+    customers: {
+        icon: 'users',
+        color: 'text-blue-400',
+        fields: ['code', 'name', 'address_1', 'address_2', 'city', 'state', 'zip', 'country', 'phone', 'email', 'notes', 'is_active'],
+        notes: 'Rows matched by code or email will update existing records. Rows with missing names are skipped.',
+    },
+    kiss: {
+        icon: 'file-code',
+        color: 'text-green-400',
+        fields: ['SHP records: Mark, Qty, Description, WeightEach, WeightTotal, Remark, Drawing', 'DET records: AssemblyMark, PartMark, QtyEach, Description, Material, Size, Length, WeightEach, WeightTotal'],
+        notes: 'SHP lines define assemblies. DET lines define parts linked to assemblies. Length format: feet-inches-sixteenths (e.g., 20-0-0).',
+    },
+    xsr: {
+        icon: 'table',
+        color: 'text-yellow-400',
+        fields: ['AssemblyMark (or Assembly)', 'PartMark (or Mark)', 'Quantity (or Qty)', 'Material (or Grade)', 'Shape (or Size)', 'Length', 'Weight'],
+        notes: 'Header-based CSV format with flexible column names. Parts without an assembly mark are assigned to DETACHED.',
+    },
+    upf: {
+        icon: 'database',
+        color: 'text-purple-400',
+        fields: ['TYPE', 'TYPEDESC', 'GRADE', 'SIZE', 'PRICE', 'PUNIT', 'THICK', 'WTFT', 'PKEY', 'FILEKEY', 'ORDERKEY'],
+        notes: 'Material catalog import from FabTrol DBF exports. Creates material types, grades, and pricing records.',
+    },
+};
+</script>
+
+<template>
+  <AppLayout title="Import Templates">
+    <Head title="Import Templates - SteelFlow MRP" />
+
+    <template #header>
+      <div class="flex flex-col gap-2">
+        <h2 class="font-semibold text-2xl text-white leading-tight">
+          Import Templates
+        </h2>
+        <p class="text-text-secondary font-mono text-sm">
+          Download template CSV files to understand the required format for each import type.
+        </p>
+      </div>
+    </template>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div
+        v-for="(template, key) in templates"
+        :key="key"
+        class="card-industrial"
+      >
+        <div class="flex items-start justify-between mb-4">
+          <div>
+            <h3 class="text-lg font-semibold text-white">
+              {{ template.name }}
+            </h3>
+            <p class="text-sm text-text-secondary mt-1">
+              {{ template.description }}
+            </p>
+          </div>
+          <a
+            :href="route('import-templates.download', { type: key })"
+            class="btn-primary shrink-0"
+          >
+            Download
+          </a>
+        </div>
+
+        <div class="bg-steel-900/60 border border-steel-700 rounded-sm p-4 mb-4">
+          <div class="text-xs uppercase tracking-wider text-text-tertiary font-semibold mb-2">
+            Expected Fields
+          </div>
+          <div class="space-y-1">
+            <div
+              v-for="field in templateDetails[key]?.fields ?? []"
+              :key="field"
+              class="text-sm text-text-secondary font-mono"
+            >
+              {{ field }}
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="templateDetails[key]?.notes"
+          class="text-xs text-text-tertiary"
+        >
+          <span class="font-semibold">Note:</span> {{ templateDetails[key].notes }}
+        </div>
+
+        <div class="mt-4 pt-4 border-t border-steel-700">
+          <div class="text-xs text-text-tertiary">
+            <span class="font-semibold">Filename:</span>
+            <span class="font-mono ml-1">{{ template.filename }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <section class="mt-10 card-industrial">
+      <h3 class="text-lg font-semibold text-white mb-4">
+        Import Guidelines
+      </h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-text-secondary">
+        <div>
+          <h4 class="font-semibold text-white mb-2">
+            General Tips
+          </h4>
+          <ul class="space-y-1 list-disc list-inside">
+            <li>Use UTF-8 encoding for all CSV files</li>
+            <li>Headers are case-insensitive and normalized to slugs</li>
+            <li>Empty rows are skipped automatically</li>
+            <li>Existing records matched by key fields will be updated</li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="font-semibold text-white mb-2">
+            Data Integrity
+          </h4>
+          <ul class="space-y-1 list-disc list-inside">
+            <li>All imports run within database transactions</li>
+            <li>Validation errors are reported with row numbers</li>
+            <li>Weight calculations support dual units (lbs/kg)</li>
+            <li>BOM imports trigger automatic weight recalculation</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AssemblyController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\DrawingController;
+use App\Http\Controllers\ImportTemplateController;
 use App\Http\Controllers\LabelController;
 use App\Http\Controllers\NestingController;
 use App\Http\Controllers\PartController;
@@ -32,6 +33,14 @@ Route::get('/login/microsoft/callback', [AuthController::class, 'handleProviderC
 
 Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [ReportController::class, 'showMainDashboard'])->name('dashboard');
+
+    // Import Template Routes
+    Route::get('/import-templates', [ImportTemplateController::class, 'index'])->name('import-templates.index');
+    Route::get('/import-templates/{type}/download', [ImportTemplateController::class, 'download'])->name('import-templates.download');
+    Route::get('/import-templates/customers', [ImportTemplateController::class, 'customers'])->name('import-templates.customers');
+    Route::get('/import-templates/kiss', [ImportTemplateController::class, 'kiss'])->name('import-templates.kiss');
+    Route::get('/import-templates/xsr', [ImportTemplateController::class, 'xsr'])->name('import-templates.xsr');
+    Route::get('/import-templates/upf', [ImportTemplateController::class, 'upf'])->name('import-templates.upf');
 
     // Customer Routes
     Route::get('/customers/import', [CustomerController::class, 'importForm'])->name('customers.import');


### PR DESCRIPTION
Add downloadable CSV templates to demonstrate the required structure for each import function:

- Customers: Contact info with address, phone, email fields
- KISS format: SHP/DET records for assemblies and parts
- XSR format: Header-based CSV with flexible column names
- UPF: Material catalog with types, grades, and pricing

Includes:
- ImportTemplateService with template generation for all formats
- ImportTemplateController with routes for each template type
- Import Templates Index page showing all available templates
- Updated Customer Import page with template download link