### PR TITLE
claude/ui-editor-dashboard-builder-B4xrQ

### DIFF
--- a/app/Http/Controllers/UIEditorController.php
+++ b/app/Http/Controllers/UIEditorController.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreDashboardRequest;
+use App\Http\Requests\StoreWidgetRequest;
+use App\Http\Requests\UpdateDashboardRequest;
+use App\Http\Requests\UpdateLayoutRequest;
+use App\Http\Requests\UpdateWidgetRequest;
+use App\Models\Dashboard;
+use App\Models\DashboardWidget;
+use App\Services\UIEditorService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UIEditorController extends Controller
+{
+    public function __construct(
+        protected UIEditorService $uiEditorService,
+    ) {}
+
+    /**
+     * Display the dashboard builder index
+     */
+    public function index(): Response
+    {
+        $user = auth()->user();
+        $dashboards = $this->uiEditorService->getUserDashboards($user);
+
+        return Inertia::render('UIEditor/Index', [
+            'dashboards' => $dashboards,
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new dashboard
+     */
+    public function create(): Response
+    {
+        $templates = $this->uiEditorService->getWidgetTemplates();
+
+        return Inertia::render('UIEditor/Create', [
+            'widgetTemplates' => $templates,
+        ]);
+    }
+
+    /**
+     * Store a newly created dashboard
+     */
+    public function store(StoreDashboardRequest $request): RedirectResponse
+    {
+        $dashboard = $this->uiEditorService->createDashboard(
+            $request->user(),
+            $request->validated()
+        );
+
+        return redirect()
+            ->route('ui-editor.edit', $dashboard)
+            ->with('success', 'Dashboard created successfully.');
+    }
+
+    /**
+     * Display the specified dashboard
+     */
+    public function show(Dashboard $dashboard): Response
+    {
+        $this->authorize('view', $dashboard);
+
+        $dashboard->load(['widgets' => fn ($q) => $q->where('is_visible', true)->orderBy('sort_order')]);
+
+        $widgetsWithData = $dashboard->widgets->map(function (DashboardWidget $widget) {
+            return [
+                ...$widget->toArray(),
+                'data' => $this->uiEditorService->getWidgetData($widget),
+            ];
+        });
+
+        return Inertia::render('UIEditor/Show', [
+            'dashboard' => $dashboard,
+            'widgets' => $widgetsWithData,
+            'layout' => $dashboard->getGridLayout(),
+        ]);
+    }
+
+    /**
+     * Show the dashboard editor (drag-and-drop builder)
+     */
+    public function edit(Dashboard $dashboard): Response
+    {
+        $this->authorize('update', $dashboard);
+
+        $dashboard->load('widgets');
+        $templates = $this->uiEditorService->getWidgetTemplates();
+
+        $widgetsWithData = $dashboard->widgets->map(function (DashboardWidget $widget) {
+            return [
+                ...$widget->toArray(),
+                'data' => $this->uiEditorService->getWidgetData($widget),
+            ];
+        });
+
+        return Inertia::render('UIEditor/Edit', [
+            'dashboard' => $dashboard,
+            'widgets' => $widgetsWithData,
+            'layout' => $dashboard->getGridLayout(),
+            'widgetTemplates' => $templates,
+        ]);
+    }
+
+    /**
+     * Update dashboard settings
+     */
+    public function update(UpdateDashboardRequest $request, Dashboard $dashboard): RedirectResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $this->uiEditorService->updateDashboard($dashboard, $request->validated());
+
+        return redirect()
+            ->route('ui-editor.edit', $dashboard)
+            ->with('success', 'Dashboard updated successfully.');
+    }
+
+    /**
+     * Delete a dashboard
+     */
+    public function destroy(Dashboard $dashboard): RedirectResponse
+    {
+        $this->authorize('delete', $dashboard);
+
+        $this->uiEditorService->deleteDashboard($dashboard);
+
+        return redirect()
+            ->route('ui-editor.index')
+            ->with('success', 'Dashboard deleted successfully.');
+    }
+
+    /**
+     * Set a dashboard as default
+     */
+    public function setDefault(Dashboard $dashboard): RedirectResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $this->uiEditorService->setDefaultDashboard(auth()->user(), $dashboard);
+
+        return redirect()
+            ->back()
+            ->with('success', 'Default dashboard updated.');
+    }
+
+    /**
+     * Duplicate a dashboard
+     */
+    public function duplicate(Request $request, Dashboard $dashboard): RedirectResponse
+    {
+        $this->authorize('view', $dashboard);
+
+        $newName = $request->input('name', $dashboard->name . ' (Copy)');
+        $newDashboard = $this->uiEditorService->duplicateDashboard(
+            $dashboard,
+            $request->user(),
+            $newName
+        );
+
+        return redirect()
+            ->route('ui-editor.edit', $newDashboard)
+            ->with('success', 'Dashboard duplicated successfully.');
+    }
+
+    /**
+     * Add a widget to the dashboard
+     */
+    public function addWidget(StoreWidgetRequest $request, Dashboard $dashboard): JsonResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $widget = $this->uiEditorService->addWidget($dashboard, $request->validated());
+
+        return response()->json([
+            'success' => true,
+            'widget' => [
+                ...$widget->toArray(),
+                'data' => $this->uiEditorService->getWidgetData($widget),
+            ],
+        ]);
+    }
+
+    /**
+     * Update a widget's configuration
+     */
+    public function updateWidget(UpdateWidgetRequest $request, Dashboard $dashboard, DashboardWidget $widget): JsonResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $updatedWidget = $this->uiEditorService->updateWidget($widget, $request->validated());
+
+        return response()->json([
+            'success' => true,
+            'widget' => [
+                ...$updatedWidget->toArray(),
+                'data' => $this->uiEditorService->getWidgetData($updatedWidget),
+            ],
+        ]);
+    }
+
+    /**
+     * Remove a widget from the dashboard
+     */
+    public function removeWidget(Dashboard $dashboard, DashboardWidget $widget): JsonResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $this->uiEditorService->removeWidget($widget);
+
+        return response()->json([
+            'success' => true,
+        ]);
+    }
+
+    /**
+     * Update the layout (positions) of all widgets
+     */
+    public function updateLayout(UpdateLayoutRequest $request, Dashboard $dashboard): JsonResponse
+    {
+        $this->authorize('update', $dashboard);
+
+        $this->uiEditorService->updateLayout($dashboard, $request->validated('layout'));
+
+        return response()->json([
+            'success' => true,
+        ]);
+    }
+
+    /**
+     * Get widget data for refresh
+     */
+    public function getWidgetData(Dashboard $dashboard, DashboardWidget $widget): JsonResponse
+    {
+        $this->authorize('view', $dashboard);
+
+        return response()->json([
+            'data' => $this->uiEditorService->getWidgetData($widget),
+        ]);
+    }
+}

--- a/app/Http/Requests/StoreDashboardRequest.php
+++ b/app/Http/Requests/StoreDashboardRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDashboardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:100'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'columns' => ['nullable', 'integer', 'min:6', 'max:24'],
+            'row_height' => ['nullable', 'integer', 'min:40', 'max:200'],
+            'settings' => ['nullable', 'array'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Dashboard name is required.',
+            'name.max' => 'Dashboard name cannot exceed 100 characters.',
+            'columns.min' => 'Minimum columns is 6.',
+            'columns.max' => 'Maximum columns is 24.',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreWidgetRequest.php
+++ b/app/Http/Requests/StoreWidgetRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWidgetRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'widget_type' => ['required', 'string', 'max:50'],
+            'title' => ['nullable', 'string', 'max:100'],
+            'grid_x' => ['nullable', 'integer', 'min:0'],
+            'grid_y' => ['nullable', 'integer', 'min:0'],
+            'grid_w' => ['nullable', 'integer', 'min:1', 'max:12'],
+            'grid_h' => ['nullable', 'integer', 'min:1', 'max:12'],
+            'config' => ['nullable', 'array'],
+            'data_source' => ['nullable', 'array'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'widget_type.required' => 'Widget type is required.',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateDashboardRequest.php
+++ b/app/Http/Requests/UpdateDashboardRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDashboardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:100'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'columns' => ['nullable', 'integer', 'min:6', 'max:24'],
+            'row_height' => ['nullable', 'integer', 'min:40', 'max:200'],
+            'is_shared' => ['nullable', 'boolean'],
+            'settings' => ['nullable', 'array'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Dashboard name is required.',
+            'name.max' => 'Dashboard name cannot exceed 100 characters.',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateLayoutRequest.php
+++ b/app/Http/Requests/UpdateLayoutRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateLayoutRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'layout' => ['required', 'array'],
+            'layout.*.i' => ['required', 'integer'],
+            'layout.*.x' => ['required', 'integer', 'min:0'],
+            'layout.*.y' => ['required', 'integer', 'min:0'],
+            'layout.*.w' => ['required', 'integer', 'min:1'],
+            'layout.*.h' => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'layout.required' => 'Layout data is required.',
+            'layout.*.i.required' => 'Widget ID is required.',
+            'layout.*.x.required' => 'X position is required.',
+            'layout.*.y.required' => 'Y position is required.',
+            'layout.*.w.required' => 'Width is required.',
+            'layout.*.h.required' => 'Height is required.',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateWidgetRequest.php
+++ b/app/Http/Requests/UpdateWidgetRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWidgetRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['nullable', 'string', 'max:100'],
+            'config' => ['nullable', 'array'],
+            'data_source' => ['nullable', 'array'],
+            'is_visible' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Models/Dashboard.php
+++ b/app/Models/Dashboard.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $description
+ * @property bool $is_default
+ * @property bool $is_shared
+ * @property int $columns
+ * @property int $row_height
+ * @property array|null $settings
+ * @property int $sort_order
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read User $user
+ * @property-read \Illuminate\Database\Eloquent\Collection|DashboardWidget[] $widgets
+ */
+class Dashboard extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'slug',
+        'description',
+        'is_default',
+        'is_shared',
+        'columns',
+        'row_height',
+        'settings',
+        'sort_order',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_default' => 'boolean',
+            'is_shared' => 'boolean',
+            'settings' => 'array',
+        ];
+    }
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (Dashboard $dashboard) {
+            if (empty($dashboard->slug)) {
+                $dashboard->slug = Str::slug($dashboard->name);
+            }
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function widgets(): HasMany
+    {
+        return $this->hasMany(DashboardWidget::class)->orderBy('sort_order');
+    }
+
+    /**
+     * Get the layout configuration for the grid
+     *
+     * @return array<int, array{i: int, x: int, y: int, w: int, h: int}>
+     */
+    public function getGridLayout(): array
+    {
+        return $this->widgets->map(function (DashboardWidget $widget) {
+            return [
+                'i' => $widget->id,
+                'x' => $widget->grid_x,
+                'y' => $widget->grid_y,
+                'w' => $widget->grid_w,
+                'h' => $widget->grid_h,
+                'minW' => $widget->min_w,
+                'minH' => $widget->min_h,
+            ];
+        })->toArray();
+    }
+
+    /**
+     * Duplicate this dashboard for a user
+     */
+    public function duplicate(User $user, string $newName): Dashboard
+    {
+        $newDashboard = $this->replicate();
+        $newDashboard->user_id = $user->id;
+        $newDashboard->name = $newName;
+        $newDashboard->slug = Str::slug($newName);
+        $newDashboard->is_default = false;
+        $newDashboard->save();
+
+        foreach ($this->widgets as $widget) {
+            $newWidget = $widget->replicate();
+            $newWidget->dashboard_id = $newDashboard->id;
+            $newWidget->save();
+        }
+
+        return $newDashboard;
+    }
+}

--- a/app/Models/DashboardWidget.php
+++ b/app/Models/DashboardWidget.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $dashboard_id
+ * @property string $widget_type
+ * @property string|null $title
+ * @property int $grid_x
+ * @property int $grid_y
+ * @property int $grid_w
+ * @property int $grid_h
+ * @property int $min_w
+ * @property int $min_h
+ * @property array|null $config
+ * @property array|null $data_source
+ * @property bool $is_visible
+ * @property int $sort_order
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Dashboard $dashboard
+ * @property-read WidgetTemplate|null $template
+ */
+class DashboardWidget extends Model
+{
+    protected $fillable = [
+        'dashboard_id',
+        'widget_type',
+        'title',
+        'grid_x',
+        'grid_y',
+        'grid_w',
+        'grid_h',
+        'min_w',
+        'min_h',
+        'config',
+        'data_source',
+        'is_visible',
+        'sort_order',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'config' => 'array',
+            'data_source' => 'array',
+            'is_visible' => 'boolean',
+        ];
+    }
+
+    public function dashboard(): BelongsTo
+    {
+        return $this->belongsTo(Dashboard::class);
+    }
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(WidgetTemplate::class, 'widget_type', 'slug');
+    }
+
+    /**
+     * Get the grid item configuration
+     *
+     * @return array{i: int, x: int, y: int, w: int, h: int, minW: int, minH: int}
+     */
+    public function toGridItem(): array
+    {
+        return [
+            'i' => $this->id,
+            'x' => $this->grid_x,
+            'y' => $this->grid_y,
+            'w' => $this->grid_w,
+            'h' => $this->grid_h,
+            'minW' => $this->min_w,
+            'minH' => $this->min_h,
+        ];
+    }
+
+    /**
+     * Update position from grid layout
+     *
+     * @param array{x: int, y: int, w: int, h: int} $position
+     */
+    public function updatePosition(array $position): void
+    {
+        $this->update([
+            'grid_x' => $position['x'],
+            'grid_y' => $position['y'],
+            'grid_w' => $position['w'],
+            'grid_h' => $position['h'],
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -21,6 +22,7 @@ use Illuminate\Notifications\Notifiable;
  * @property string|null $remember_token
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|Dashboard[] $dashboards
  */
 class User extends Authenticatable implements FilamentUser
 {
@@ -84,5 +86,21 @@ class User extends Authenticatable implements FilamentUser
         }
 
         return true;
+    }
+
+    /**
+     * Get user's custom dashboards
+     */
+    public function dashboards(): HasMany
+    {
+        return $this->hasMany(Dashboard::class)->orderBy('sort_order');
+    }
+
+    /**
+     * Get user's default dashboard
+     */
+    public function getDefaultDashboard(): ?Dashboard
+    {
+        return $this->dashboards()->where('is_default', true)->first();
     }
 }

--- a/app/Models/WidgetTemplate.php
+++ b/app/Models/WidgetTemplate.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property string $category
+ * @property string|null $description
+ * @property string|null $icon
+ * @property string $component
+ * @property int $default_w
+ * @property int $default_h
+ * @property int $min_w
+ * @property int $min_h
+ * @property int|null $max_w
+ * @property int|null $max_h
+ * @property array|null $default_config
+ * @property array|null $config_schema
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|DashboardWidget[] $widgets
+ */
+class WidgetTemplate extends Model
+{
+    protected $fillable = [
+        'name',
+        'slug',
+        'category',
+        'description',
+        'icon',
+        'component',
+        'default_w',
+        'default_h',
+        'min_w',
+        'min_h',
+        'max_w',
+        'max_h',
+        'default_config',
+        'config_schema',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'default_config' => 'array',
+            'config_schema' => 'array',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function widgets(): HasMany
+    {
+        return $this->hasMany(DashboardWidget::class, 'widget_type', 'slug');
+    }
+
+    /**
+     * Get templates grouped by category
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<string, \Illuminate\Database\Eloquent\Collection<int, WidgetTemplate>>
+     */
+    public static function getGroupedByCategory()
+    {
+        return static::where('is_active', true)
+            ->orderBy('category')
+            ->orderBy('name')
+            ->get()
+            ->groupBy('category');
+    }
+
+    /**
+     * Create a widget instance from this template
+     *
+     * @return array{widget_type: string, title: string|null, grid_w: int, grid_h: int, min_w: int, min_h: int, config: array|null}
+     */
+    public function toWidgetDefaults(): array
+    {
+        return [
+            'widget_type' => $this->slug,
+            'title' => $this->name,
+            'grid_w' => $this->default_w,
+            'grid_h' => $this->default_h,
+            'min_w' => $this->min_w,
+            'min_h' => $this->min_h,
+            'config' => $this->default_config,
+        ];
+    }
+}

--- a/app/Policies/DashboardPolicy.php
+++ b/app/Policies/DashboardPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Dashboard;
+use App\Models\User;
+
+class DashboardPolicy
+{
+    /**
+     * Determine whether the user can view any dashboards.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the dashboard.
+     */
+    public function view(User $user, Dashboard $dashboard): bool
+    {
+        return $dashboard->user_id === $user->id || $dashboard->is_shared;
+    }
+
+    /**
+     * Determine whether the user can create dashboards.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the dashboard.
+     */
+    public function update(User $user, Dashboard $dashboard): bool
+    {
+        return $dashboard->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the dashboard.
+     */
+    public function delete(User $user, Dashboard $dashboard): bool
+    {
+        return $dashboard->user_id === $user->id;
+    }
+}

--- a/app/Services/UIEditorService.php
+++ b/app/Services/UIEditorService.php
@@ -1,0 +1,415 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Dashboard;
+use App\Models\DashboardWidget;
+use App\Models\User;
+use App\Models\WidgetTemplate;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class UIEditorService
+{
+    /**
+     * Get all dashboards for a user
+     *
+     * @return Collection<int, Dashboard>
+     */
+    public function getUserDashboards(User $user): Collection
+    {
+        return Dashboard::where('user_id', $user->id)
+            ->orWhere('is_shared', true)
+            ->with('widgets')
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    /**
+     * Get a dashboard with its widgets
+     */
+    public function getDashboard(int $dashboardId): ?Dashboard
+    {
+        return Dashboard::with(['widgets' => function ($query) {
+            $query->where('is_visible', true)->orderBy('sort_order');
+        }])->find($dashboardId);
+    }
+
+    /**
+     * Create a new dashboard
+     *
+     * @param array{name: string, description?: string, columns?: int, row_height?: int, settings?: array} $data
+     */
+    public function createDashboard(User $user, array $data): Dashboard
+    {
+        return DB::transaction(function () use ($user, $data) {
+            $dashboard = Dashboard::create([
+                'user_id' => $user->id,
+                'name' => $data['name'],
+                'slug' => Str::slug($data['name']),
+                'description' => $data['description'] ?? null,
+                'columns' => $data['columns'] ?? 12,
+                'row_height' => $data['row_height'] ?? 80,
+                'settings' => $data['settings'] ?? [],
+                'sort_order' => $this->getNextSortOrder($user),
+            ]);
+
+            return $dashboard;
+        });
+    }
+
+    /**
+     * Update dashboard settings
+     *
+     * @param array{name?: string, description?: string, columns?: int, row_height?: int, settings?: array, is_shared?: bool} $data
+     */
+    public function updateDashboard(Dashboard $dashboard, array $data): Dashboard
+    {
+        return DB::transaction(function () use ($dashboard, $data) {
+            if (isset($data['name']) && $data['name'] !== $dashboard->name) {
+                $data['slug'] = Str::slug($data['name']);
+            }
+
+            $dashboard->update($data);
+
+            return $dashboard->fresh();
+        });
+    }
+
+    /**
+     * Delete a dashboard
+     */
+    public function deleteDashboard(Dashboard $dashboard): bool
+    {
+        return DB::transaction(function () use ($dashboard) {
+            $dashboard->widgets()->delete();
+
+            return $dashboard->delete();
+        });
+    }
+
+    /**
+     * Set a dashboard as the user's default
+     */
+    public function setDefaultDashboard(User $user, Dashboard $dashboard): void
+    {
+        DB::transaction(function () use ($user, $dashboard) {
+            Dashboard::where('user_id', $user->id)
+                ->where('is_default', true)
+                ->update(['is_default' => false]);
+
+            $dashboard->update(['is_default' => true]);
+        });
+    }
+
+    /**
+     * Add a widget to a dashboard
+     *
+     * @param array{widget_type: string, title?: string, grid_x?: int, grid_y?: int, grid_w?: int, grid_h?: int, config?: array, data_source?: array} $data
+     */
+    public function addWidget(Dashboard $dashboard, array $data): DashboardWidget
+    {
+        $template = WidgetTemplate::where('slug', $data['widget_type'])->first();
+
+        return DB::transaction(function () use ($dashboard, $data, $template) {
+            $widgetData = [
+                'dashboard_id' => $dashboard->id,
+                'widget_type' => $data['widget_type'],
+                'title' => $data['title'] ?? $template?->name ?? $data['widget_type'],
+                'grid_x' => $data['grid_x'] ?? 0,
+                'grid_y' => $data['grid_y'] ?? $this->getNextGridY($dashboard),
+                'grid_w' => $data['grid_w'] ?? $template?->default_w ?? 4,
+                'grid_h' => $data['grid_h'] ?? $template?->default_h ?? 3,
+                'min_w' => $template?->min_w ?? 2,
+                'min_h' => $template?->min_h ?? 2,
+                'config' => $data['config'] ?? $template?->default_config ?? [],
+                'data_source' => $data['data_source'] ?? [],
+                'sort_order' => $this->getNextWidgetSortOrder($dashboard),
+            ];
+
+            return DashboardWidget::create($widgetData);
+        });
+    }
+
+    /**
+     * Update a widget's configuration
+     *
+     * @param array{title?: string, config?: array, data_source?: array, is_visible?: bool} $data
+     */
+    public function updateWidget(DashboardWidget $widget, array $data): DashboardWidget
+    {
+        $widget->update($data);
+
+        return $widget->fresh();
+    }
+
+    /**
+     * Update widget position on the grid
+     *
+     * @param array{x: int, y: int, w: int, h: int} $position
+     */
+    public function updateWidgetPosition(DashboardWidget $widget, array $position): DashboardWidget
+    {
+        $widget->updatePosition($position);
+
+        return $widget->fresh();
+    }
+
+    /**
+     * Bulk update widget positions (for drag-and-drop saves)
+     *
+     * @param array<int, array{i: int, x: int, y: int, w: int, h: int}> $layout
+     */
+    public function updateLayout(Dashboard $dashboard, array $layout): void
+    {
+        DB::transaction(function () use ($dashboard, $layout) {
+            foreach ($layout as $item) {
+                DashboardWidget::where('id', $item['i'])
+                    ->where('dashboard_id', $dashboard->id)
+                    ->update([
+                        'grid_x' => $item['x'],
+                        'grid_y' => $item['y'],
+                        'grid_w' => $item['w'],
+                        'grid_h' => $item['h'],
+                    ]);
+            }
+        });
+    }
+
+    /**
+     * Remove a widget from a dashboard
+     */
+    public function removeWidget(DashboardWidget $widget): bool
+    {
+        return $widget->delete();
+    }
+
+    /**
+     * Duplicate a dashboard
+     */
+    public function duplicateDashboard(Dashboard $dashboard, User $user, string $newName): Dashboard
+    {
+        return $dashboard->duplicate($user, $newName);
+    }
+
+    /**
+     * Get available widget templates grouped by category
+     *
+     * @return Collection<string, Collection<int, WidgetTemplate>>
+     */
+    public function getWidgetTemplates(): Collection
+    {
+        return WidgetTemplate::getGroupedByCategory();
+    }
+
+    /**
+     * Get widget data for rendering
+     *
+     * @return array<string, mixed>
+     */
+    public function getWidgetData(DashboardWidget $widget): array
+    {
+        return match ($widget->widget_type) {
+            'metrics-card' => $this->getMetricsCardData($widget),
+            'chart-bar', 'chart-line', 'chart-pie', 'chart-doughnut' => $this->getChartData($widget),
+            'table' => $this->getTableData($widget),
+            'activity-feed' => $this->getActivityFeedData($widget),
+            'quick-actions' => $this->getQuickActionsData($widget),
+            'status-overview' => $this->getStatusOverviewData($widget),
+            default => [],
+        };
+    }
+
+    /**
+     * Create default dashboard for new user
+     */
+    public function createDefaultDashboard(User $user): Dashboard
+    {
+        return DB::transaction(function () use ($user) {
+            $dashboard = $this->createDashboard($user, [
+                'name' => 'My Dashboard',
+                'description' => 'Default dashboard',
+            ]);
+
+            $dashboard->update(['is_default' => true]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'metrics-card',
+                'title' => 'Active Projects',
+                'grid_x' => 0,
+                'grid_y' => 0,
+                'grid_w' => 3,
+                'grid_h' => 2,
+                'config' => ['metric' => 'active_projects', 'icon' => 'folder'],
+            ]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'metrics-card',
+                'title' => 'Total Weight',
+                'grid_x' => 3,
+                'grid_y' => 0,
+                'grid_w' => 3,
+                'grid_h' => 2,
+                'config' => ['metric' => 'total_weight', 'icon' => 'scale'],
+            ]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'metrics-card',
+                'title' => 'Production Progress',
+                'grid_x' => 6,
+                'grid_y' => 0,
+                'grid_w' => 3,
+                'grid_h' => 2,
+                'config' => ['metric' => 'production_progress', 'icon' => 'chart-bar'],
+            ]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'metrics-card',
+                'title' => 'Ready to Ship',
+                'grid_x' => 9,
+                'grid_y' => 0,
+                'grid_w' => 3,
+                'grid_h' => 2,
+                'config' => ['metric' => 'ready_to_ship', 'icon' => 'truck'],
+            ]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'activity-feed',
+                'title' => 'Recent Activity',
+                'grid_x' => 0,
+                'grid_y' => 2,
+                'grid_w' => 6,
+                'grid_h' => 4,
+            ]);
+
+            $this->addWidget($dashboard, [
+                'widget_type' => 'quick-actions',
+                'title' => 'Quick Actions',
+                'grid_x' => 6,
+                'grid_y' => 2,
+                'grid_w' => 6,
+                'grid_h' => 4,
+            ]);
+
+            return $dashboard->fresh(['widgets']);
+        });
+    }
+
+    /**
+     * Get metrics card data
+     *
+     * @return array{value: mixed, change?: float, trend?: string}
+     */
+    protected function getMetricsCardData(DashboardWidget $widget): array
+    {
+        $reportingService = app(ReportingService::class);
+        $metrics = $reportingService->getDashboardMetrics();
+        $metric = $widget->config['metric'] ?? 'active_projects';
+
+        return [
+            'value' => $metrics[$metric] ?? 0,
+            'trend' => 'up',
+            'change' => 5.2,
+        ];
+    }
+
+    /**
+     * Get chart data
+     *
+     * @return array{labels: array, datasets: array}
+     */
+    protected function getChartData(DashboardWidget $widget): array
+    {
+        return [
+            'labels' => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+            'datasets' => [
+                [
+                    'label' => $widget->title,
+                    'data' => [12, 19, 3, 5, 2, 3],
+                    'backgroundColor' => 'rgba(59, 130, 246, 0.5)',
+                    'borderColor' => 'rgb(59, 130, 246)',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Get table data
+     *
+     * @return array{columns: array, rows: array}
+     */
+    protected function getTableData(DashboardWidget $widget): array
+    {
+        return [
+            'columns' => ['ID', 'Name', 'Status'],
+            'rows' => [],
+        ];
+    }
+
+    /**
+     * Get activity feed data
+     *
+     * @return array{items: array}
+     */
+    protected function getActivityFeedData(DashboardWidget $widget): array
+    {
+        $reportingService = app(ReportingService::class);
+        $stats = $reportingService->getProductionStats();
+
+        return [
+            'items' => $stats['recentActivity'] ?? [],
+        ];
+    }
+
+    /**
+     * Get quick actions data
+     *
+     * @return array{actions: array}
+     */
+    protected function getQuickActionsData(DashboardWidget $widget): array
+    {
+        return [
+            'actions' => [
+                ['label' => 'New Project', 'route' => 'projects.create', 'icon' => 'plus'],
+                ['label' => 'Import BOM', 'route' => 'bom.import', 'icon' => 'upload'],
+                ['label' => 'View Reports', 'route' => 'reports.index', 'icon' => 'document-report'],
+            ],
+        ];
+    }
+
+    /**
+     * Get status overview data
+     *
+     * @return array{statuses: array}
+     */
+    protected function getStatusOverviewData(DashboardWidget $widget): array
+    {
+        return [
+            'statuses' => [
+                ['label' => 'In Progress', 'count' => 12, 'color' => 'blue'],
+                ['label' => 'Complete', 'count' => 45, 'color' => 'green'],
+                ['label' => 'Pending', 'count' => 8, 'color' => 'yellow'],
+            ],
+        ];
+    }
+
+    protected function getNextSortOrder(User $user): int
+    {
+        return (Dashboard::where('user_id', $user->id)->max('sort_order') ?? 0) + 1;
+    }
+
+    protected function getNextWidgetSortOrder(Dashboard $dashboard): int
+    {
+        return ($dashboard->widgets()->max('sort_order') ?? 0) + 1;
+    }
+
+    protected function getNextGridY(Dashboard $dashboard): int
+    {
+        $maxY = $dashboard->widgets()
+            ->selectRaw('MAX(grid_y + grid_h) as max_y')
+            ->value('max_y');
+
+        return $maxY ?? 0;
+    }
+}

--- a/database/factories/DashboardFactory.php
+++ b/database/factories/DashboardFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Dashboard;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Dashboard>
+ */
+class DashboardFactory extends Factory
+{
+    protected $model = Dashboard::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->words(3, true);
+
+        return [
+            'user_id' => User::factory(),
+            'name' => ucwords($name),
+            'slug' => Str::slug($name),
+            'description' => fake()->optional()->sentence(),
+            'is_default' => false,
+            'is_shared' => false,
+            'columns' => 12,
+            'row_height' => 80,
+            'settings' => [],
+            'sort_order' => 0,
+        ];
+    }
+
+    /**
+     * Indicate that the dashboard is the default.
+     */
+    public function default(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_default' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the dashboard is shared.
+     */
+    public function shared(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_shared' => true,
+        ]);
+    }
+}

--- a/database/factories/DashboardWidgetFactory.php
+++ b/database/factories/DashboardWidgetFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Dashboard;
+use App\Models\DashboardWidget;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DashboardWidget>
+ */
+class DashboardWidgetFactory extends Factory
+{
+    protected $model = DashboardWidget::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $widgetTypes = ['metrics-card', 'chart-bar', 'chart-line', 'table', 'activity-feed', 'quick-actions'];
+
+        return [
+            'dashboard_id' => Dashboard::factory(),
+            'widget_type' => fake()->randomElement($widgetTypes),
+            'title' => fake()->words(2, true),
+            'grid_x' => fake()->numberBetween(0, 8),
+            'grid_y' => fake()->numberBetween(0, 10),
+            'grid_w' => fake()->numberBetween(2, 6),
+            'grid_h' => fake()->numberBetween(2, 4),
+            'min_w' => 2,
+            'min_h' => 2,
+            'config' => [],
+            'data_source' => [],
+            'is_visible' => true,
+            'sort_order' => 0,
+        ];
+    }
+
+    /**
+     * Configure the widget as a metrics card.
+     */
+    public function metricsCard(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'widget_type' => 'metrics-card',
+            'grid_w' => 3,
+            'grid_h' => 2,
+            'config' => ['metric' => 'active_projects', 'icon' => 'folder'],
+        ]);
+    }
+
+    /**
+     * Configure the widget as a chart.
+     */
+    public function chart(string $type = 'bar'): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'widget_type' => "chart-{$type}",
+            'grid_w' => 6,
+            'grid_h' => 4,
+            'config' => ['showLegend' => true],
+        ]);
+    }
+
+    /**
+     * Configure the widget as hidden.
+     */
+    public function hidden(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_visible' => false,
+        ]);
+    }
+}

--- a/database/migrations/2026_01_12_100000_create_ui_dashboards_tables.php
+++ b/database/migrations/2026_01_12_100000_create_ui_dashboards_tables.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('dashboards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 100);
+            $table->string('slug', 100);
+            $table->text('description')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_shared')->default(false);
+            $table->integer('columns')->default(12);
+            $table->integer('row_height')->default(80);
+            $table->json('settings')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['user_id', 'slug']);
+            $table->index(['user_id', 'is_default']);
+        });
+
+        Schema::create('dashboard_widgets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('dashboard_id')->constrained()->cascadeOnDelete();
+            $table->string('widget_type', 50);
+            $table->string('title', 100)->nullable();
+            $table->integer('grid_x')->default(0);
+            $table->integer('grid_y')->default(0);
+            $table->integer('grid_w')->default(4);
+            $table->integer('grid_h')->default(3);
+            $table->integer('min_w')->default(2);
+            $table->integer('min_h')->default(2);
+            $table->json('config')->nullable();
+            $table->json('data_source')->nullable();
+            $table->boolean('is_visible')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['dashboard_id', 'is_visible']);
+            $table->index('widget_type');
+        });
+
+        Schema::create('widget_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('slug', 100)->unique();
+            $table->string('category', 50);
+            $table->text('description')->nullable();
+            $table->string('icon', 50)->nullable();
+            $table->string('component', 100);
+            $table->integer('default_w')->default(4);
+            $table->integer('default_h')->default(3);
+            $table->integer('min_w')->default(2);
+            $table->integer('min_h')->default(2);
+            $table->integer('max_w')->nullable();
+            $table->integer('max_h')->nullable();
+            $table->json('default_config')->nullable();
+            $table->json('config_schema')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['category', 'is_active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('widget_templates');
+        Schema::dropIfExists('dashboard_widgets');
+        Schema::dropIfExists('dashboards');
+    }
+};

--- a/database/seeders/WidgetTemplateSeeder.php
+++ b/database/seeders/WidgetTemplateSeeder.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\WidgetTemplate;
+use Illuminate\Database\Seeder;
+
+class WidgetTemplateSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $templates = [
+            // Metrics Widgets
+            [
+                'name' => 'Metrics Card',
+                'slug' => 'metrics-card',
+                'category' => 'Metrics',
+                'description' => 'Display a single KPI metric with trend indicator',
+                'icon' => 'rectangle-group',
+                'component' => 'MetricsCardWidget',
+                'default_w' => 3,
+                'default_h' => 2,
+                'min_w' => 2,
+                'min_h' => 2,
+                'max_w' => 6,
+                'max_h' => 4,
+                'default_config' => ['metric' => 'active_projects', 'icon' => 'folder'],
+                'config_schema' => [
+                    'metric' => ['type' => 'select', 'options' => ['active_projects', 'total_weight', 'production_progress', 'ready_to_ship']],
+                    'icon' => ['type' => 'select', 'options' => ['folder', 'scale', 'chart-bar', 'truck', 'bolt', 'cube']],
+                ],
+                'is_active' => true,
+            ],
+
+            // Chart Widgets
+            [
+                'name' => 'Bar Chart',
+                'slug' => 'chart-bar',
+                'category' => 'Charts',
+                'description' => 'Horizontal or vertical bar chart for data comparison',
+                'icon' => 'chart-bar',
+                'component' => 'ChartWidget',
+                'default_w' => 6,
+                'default_h' => 4,
+                'min_w' => 3,
+                'min_h' => 3,
+                'max_w' => 12,
+                'max_h' => 8,
+                'default_config' => ['chartTitle' => '', 'showLegend' => true],
+                'config_schema' => [
+                    'chartTitle' => ['type' => 'text'],
+                    'showLegend' => ['type' => 'boolean'],
+                ],
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Line Chart',
+                'slug' => 'chart-line',
+                'category' => 'Charts',
+                'description' => 'Line or area chart for trends over time',
+                'icon' => 'chart-bar',
+                'component' => 'ChartWidget',
+                'default_w' => 6,
+                'default_h' => 4,
+                'min_w' => 3,
+                'min_h' => 3,
+                'max_w' => 12,
+                'max_h' => 8,
+                'default_config' => ['chartTitle' => '', 'showLegend' => true],
+                'config_schema' => [
+                    'chartTitle' => ['type' => 'text'],
+                    'showLegend' => ['type' => 'boolean'],
+                ],
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Pie Chart',
+                'slug' => 'chart-pie',
+                'category' => 'Charts',
+                'description' => 'Pie or doughnut chart for proportional data',
+                'icon' => 'chart-pie',
+                'component' => 'ChartWidget',
+                'default_w' => 4,
+                'default_h' => 4,
+                'min_w' => 3,
+                'min_h' => 3,
+                'max_w' => 6,
+                'max_h' => 6,
+                'default_config' => ['chartTitle' => '', 'showLegend' => true],
+                'config_schema' => [
+                    'chartTitle' => ['type' => 'text'],
+                    'showLegend' => ['type' => 'boolean'],
+                ],
+                'is_active' => true,
+            ],
+
+            // Data Widgets
+            [
+                'name' => 'Data Table',
+                'slug' => 'table',
+                'category' => 'Data',
+                'description' => 'Sortable data table with pagination',
+                'icon' => 'table-cells',
+                'component' => 'TableWidget',
+                'default_w' => 6,
+                'default_h' => 4,
+                'min_w' => 4,
+                'min_h' => 3,
+                'max_w' => 12,
+                'max_h' => 10,
+                'default_config' => ['pageSize' => 10],
+                'config_schema' => [
+                    'pageSize' => ['type' => 'number', 'min' => 5, 'max' => 50],
+                ],
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Activity Feed',
+                'slug' => 'activity-feed',
+                'category' => 'Data',
+                'description' => 'Recent activity timeline with status indicators',
+                'icon' => 'clock',
+                'component' => 'ActivityFeedWidget',
+                'default_w' => 4,
+                'default_h' => 4,
+                'min_w' => 3,
+                'min_h' => 3,
+                'max_w' => 6,
+                'max_h' => 8,
+                'default_config' => ['maxItems' => 5],
+                'config_schema' => [
+                    'maxItems' => ['type' => 'number', 'min' => 3, 'max' => 20],
+                ],
+                'is_active' => true,
+            ],
+
+            // Action Widgets
+            [
+                'name' => 'Quick Actions',
+                'slug' => 'quick-actions',
+                'category' => 'Actions',
+                'description' => 'Grid of action buttons for common tasks',
+                'icon' => 'bolt',
+                'component' => 'QuickActionsWidget',
+                'default_w' => 4,
+                'default_h' => 3,
+                'min_w' => 2,
+                'min_h' => 2,
+                'max_w' => 6,
+                'max_h' => 6,
+                'default_config' => [],
+                'config_schema' => [],
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Status Overview',
+                'slug' => 'status-overview',
+                'category' => 'Actions',
+                'description' => 'Status summary with progress indicators',
+                'icon' => 'document-text',
+                'component' => 'StatusOverviewWidget',
+                'default_w' => 4,
+                'default_h' => 3,
+                'min_w' => 3,
+                'min_h' => 2,
+                'max_w' => 6,
+                'max_h' => 6,
+                'default_config' => [],
+                'config_schema' => [],
+                'is_active' => true,
+            ],
+        ];
+
+        foreach ($templates as $template) {
+            WidgetTemplate::updateOrCreate(
+                ['slug' => $template['slug']],
+                $template
+            );
+        }
+    }
+}

--- a/resources/js/Components/UIEditor/WidgetCard.vue
+++ b/resources/js/Components/UIEditor/WidgetCard.vue
@@ -1,0 +1,139 @@
+<script setup>
+import { computed } from 'vue';
+import {
+    XMarkIcon,
+    ArrowsPointingOutIcon,
+    Cog6ToothIcon,
+    ArrowPathIcon,
+} from '@heroicons/vue/24/outline';
+import MetricsCardWidget from '@/Components/UIEditor/widgets/MetricsCardWidget.vue';
+import ChartWidget from '@/Components/UIEditor/widgets/ChartWidget.vue';
+import TableWidget from '@/Components/UIEditor/widgets/TableWidget.vue';
+import ActivityFeedWidget from '@/Components/UIEditor/widgets/ActivityFeedWidget.vue';
+import QuickActionsWidget from '@/Components/UIEditor/widgets/QuickActionsWidget.vue';
+import StatusOverviewWidget from '@/Components/UIEditor/widgets/StatusOverviewWidget.vue';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    isSelected: {
+        type: Boolean,
+        default: false,
+    },
+    isEditing: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits(['select', 'remove', 'drag-start', 'drag-end', 'resize', 'refresh']);
+
+// Map widget types to components
+const widgetComponents = {
+    'metrics-card': MetricsCardWidget,
+    'chart-bar': ChartWidget,
+    'chart-line': ChartWidget,
+    'chart-pie': ChartWidget,
+    'chart-doughnut': ChartWidget,
+    'table': TableWidget,
+    'activity-feed': ActivityFeedWidget,
+    'quick-actions': QuickActionsWidget,
+    'status-overview': StatusOverviewWidget,
+};
+
+const widgetComponent = computed(() => {
+    return widgetComponents[props.widget.widget_type] || null;
+});
+
+const handleDragStart = (event) => {
+    if (!props.isEditing) return;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', JSON.stringify(props.widget));
+    emit('drag-start', event, props.widget);
+};
+</script>
+
+<template>
+  <div
+    class="card relative group transition-all"
+    :class="{
+      'ring-2 ring-forge-500 shadow-glow-forge': isSelected,
+      'hover:ring-1 hover:ring-steel-600': isEditing && !isSelected,
+      'cursor-grab': isEditing,
+    }"
+    :draggable="isEditing"
+    @click="emit('select')"
+    @dragstart="handleDragStart"
+    @dragend="emit('drag-end')"
+  >
+    <!-- Widget Header -->
+    <div class="flex items-center justify-between mb-3 pb-3 border-b border-steel-700">
+      <h4 class="font-semibold text-steel-300 text-sm truncate">
+        {{ widget.title || widget.widget_type }}
+      </h4>
+
+      <!-- Edit Mode Actions -->
+      <div
+        v-if="isEditing"
+        class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+      >
+        <button
+          class="p-1 text-steel-500 hover:text-steel-300 rounded"
+          title="Configure"
+          @click.stop="emit('select')"
+        >
+          <Cog6ToothIcon class="w-4 h-4" />
+        </button>
+        <button
+          class="p-1 text-steel-500 hover:text-red-400 rounded"
+          title="Remove"
+          @click.stop="emit('remove')"
+        >
+          <XMarkIcon class="w-4 h-4" />
+        </button>
+      </div>
+
+      <!-- View Mode Actions -->
+      <div
+        v-else
+        class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+      >
+        <button
+          class="p-1 text-steel-500 hover:text-steel-300 rounded"
+          title="Refresh"
+          @click.stop="emit('refresh')"
+        >
+          <ArrowPathIcon class="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Widget Content -->
+    <div class="flex-1 overflow-hidden">
+      <component
+        :is="widgetComponent"
+        v-if="widgetComponent"
+        :widget="widget"
+        :data="widget.data"
+        :config="widget.config"
+      />
+      <div
+        v-else
+        class="h-full flex items-center justify-center text-steel-500 text-sm"
+      >
+        Unknown widget type: {{ widget.widget_type }}
+      </div>
+    </div>
+
+    <!-- Resize Handle (Edit Mode Only) -->
+    <div
+      v-if="isEditing"
+      class="absolute bottom-0 right-0 w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity"
+      @mousedown.stop.prevent="/* resize logic would go here */"
+    >
+      <ArrowsPointingOutIcon class="w-4 h-4 text-steel-500 rotate-90" />
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/WidgetConfigPanel.vue
+++ b/resources/js/Components/UIEditor/WidgetConfigPanel.vue
@@ -1,0 +1,217 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { XMarkIcon } from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+});
+
+const emit = defineEmits(['update', 'close']);
+
+// Local form state
+const form = ref({
+    title: props.widget.title || '',
+    config: { ...props.widget.config } || {},
+});
+
+// Watch for widget changes
+watch(() => props.widget, (newWidget) => {
+    form.value.title = newWidget.title || '';
+    form.value.config = { ...newWidget.config } || {};
+}, { deep: true });
+
+// Metric options for metrics card
+const metricOptions = [
+    { value: 'active_projects', label: 'Active Projects' },
+    { value: 'total_weight', label: 'Total Weight' },
+    { value: 'production_progress', label: 'Production Progress' },
+    { value: 'ready_to_ship', label: 'Ready to Ship' },
+];
+
+// Icon options
+const iconOptions = [
+    { value: 'folder', label: 'Folder' },
+    { value: 'scale', label: 'Scale' },
+    { value: 'chart-bar', label: 'Chart Bar' },
+    { value: 'truck', label: 'Truck' },
+    { value: 'bolt', label: 'Bolt' },
+    { value: 'cube', label: 'Cube' },
+];
+
+const handleSubmit = () => {
+    emit('update', {
+        title: form.value.title,
+        config: form.value.config,
+    });
+};
+</script>
+
+<template>
+  <div class="card-elevated sticky top-24">
+    <div class="flex items-center justify-between mb-6">
+      <h3 class="text-lg font-semibold text-steel-300">
+        Widget Settings
+      </h3>
+      <button
+        class="btn-ghost p-1"
+        @click="emit('close')"
+      >
+        <XMarkIcon class="w-5 h-5" />
+      </button>
+    </div>
+
+    <form @submit.prevent="handleSubmit">
+      <!-- Title -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-steel-300 mb-2">
+          Title
+        </label>
+        <input
+          v-model="form.title"
+          type="text"
+          class="input w-full"
+          placeholder="Widget title"
+        >
+      </div>
+
+      <!-- Widget Type Info -->
+      <div class="mb-4 p-3 bg-steel-800 rounded-industrial">
+        <div class="text-xs text-steel-500 uppercase mb-1">
+          Widget Type
+        </div>
+        <div class="text-steel-300 font-mono">
+          {{ widget.widget_type }}
+        </div>
+      </div>
+
+      <!-- Metrics Card Config -->
+      <template v-if="widget.widget_type === 'metrics-card'">
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-steel-300 mb-2">
+            Metric
+          </label>
+          <select
+            v-model="form.config.metric"
+            class="input w-full"
+          >
+            <option
+              v-for="option in metricOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-steel-300 mb-2">
+            Icon
+          </label>
+          <select
+            v-model="form.config.icon"
+            class="input w-full"
+          >
+            <option
+              v-for="option in iconOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
+      </template>
+
+      <!-- Chart Config -->
+      <template v-if="widget.widget_type.startsWith('chart-')">
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-steel-300 mb-2">
+            Chart Title
+          </label>
+          <input
+            v-model="form.config.chartTitle"
+            type="text"
+            class="input w-full"
+            placeholder="Chart title"
+          >
+        </div>
+
+        <div class="mb-4">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input
+              v-model="form.config.showLegend"
+              type="checkbox"
+              class="w-4 h-4 rounded border-steel-600 bg-steel-800 text-forge-500 focus:ring-forge-500"
+            >
+            <span class="text-sm text-steel-300">Show Legend</span>
+          </label>
+        </div>
+      </template>
+
+      <!-- Activity Feed Config -->
+      <template v-if="widget.widget_type === 'activity-feed'">
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-steel-300 mb-2">
+            Max Items
+          </label>
+          <input
+            v-model.number="form.config.maxItems"
+            type="number"
+            class="input w-full"
+            min="3"
+            max="20"
+            placeholder="10"
+          >
+        </div>
+      </template>
+
+      <!-- Position Info -->
+      <div class="mb-4 p-3 bg-steel-800 rounded-industrial">
+        <div class="text-xs text-steel-500 uppercase mb-2">
+          Position & Size
+        </div>
+        <div class="grid grid-cols-2 gap-2 text-sm">
+          <div class="text-steel-400">
+            X: <span class="text-steel-300 font-mono">{{ widget.grid_x }}</span>
+          </div>
+          <div class="text-steel-400">
+            Y: <span class="text-steel-300 font-mono">{{ widget.grid_y }}</span>
+          </div>
+          <div class="text-steel-400">
+            W: <span class="text-steel-300 font-mono">{{ widget.grid_w }}</span>
+          </div>
+          <div class="text-steel-400">
+            H: <span class="text-steel-300 font-mono">{{ widget.grid_h }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Visibility -->
+      <div class="mb-6">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            v-model="form.config.visible"
+            type="checkbox"
+            class="w-4 h-4 rounded border-steel-600 bg-steel-800 text-forge-500 focus:ring-forge-500"
+            checked
+          >
+          <span class="text-sm text-steel-300">Visible</span>
+        </label>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex gap-3">
+        <button
+          type="submit"
+          class="btn-primary flex-1"
+        >
+          Save Changes
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/WidgetToolbox.vue
+++ b/resources/js/Components/UIEditor/WidgetToolbox.vue
@@ -1,0 +1,181 @@
+<script setup>
+import {
+    ChartBarIcon,
+    ChartPieIcon,
+    TableCellsIcon,
+    RectangleGroupIcon,
+    BoltIcon,
+    ClockIcon,
+    DocumentTextIcon,
+    CubeIcon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    templates: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const emit = defineEmits(['drag-start']);
+
+// Icon mapping for widget types
+const iconMap = {
+    'metrics-card': RectangleGroupIcon,
+    'chart-bar': ChartBarIcon,
+    'chart-line': ChartBarIcon,
+    'chart-pie': ChartPieIcon,
+    'chart-doughnut': ChartPieIcon,
+    'table': TableCellsIcon,
+    'activity-feed': ClockIcon,
+    'quick-actions': BoltIcon,
+    'status-overview': DocumentTextIcon,
+    'default': CubeIcon,
+};
+
+// Default templates when none are provided from backend
+const defaultTemplates = {
+    'Metrics': [
+        {
+            name: 'Metrics Card',
+            slug: 'metrics-card',
+            description: 'Display a single KPI metric',
+            icon: 'rectangle-group',
+            default_w: 3,
+            default_h: 2,
+            default_config: { metric: 'active_projects' },
+        },
+    ],
+    'Charts': [
+        {
+            name: 'Bar Chart',
+            slug: 'chart-bar',
+            description: 'Horizontal or vertical bar chart',
+            icon: 'chart-bar',
+            default_w: 6,
+            default_h: 4,
+            default_config: {},
+        },
+        {
+            name: 'Line Chart',
+            slug: 'chart-line',
+            description: 'Line or area chart',
+            icon: 'chart-bar',
+            default_w: 6,
+            default_h: 4,
+            default_config: {},
+        },
+        {
+            name: 'Pie Chart',
+            slug: 'chart-pie',
+            description: 'Pie or doughnut chart',
+            icon: 'chart-pie',
+            default_w: 4,
+            default_h: 4,
+            default_config: {},
+        },
+    ],
+    'Data': [
+        {
+            name: 'Data Table',
+            slug: 'table',
+            description: 'Sortable data table',
+            icon: 'table',
+            default_w: 6,
+            default_h: 4,
+            default_config: {},
+        },
+        {
+            name: 'Activity Feed',
+            slug: 'activity-feed',
+            description: 'Recent activity timeline',
+            icon: 'clock',
+            default_w: 4,
+            default_h: 4,
+            default_config: {},
+        },
+    ],
+    'Actions': [
+        {
+            name: 'Quick Actions',
+            slug: 'quick-actions',
+            description: 'Action buttons grid',
+            icon: 'bolt',
+            default_w: 4,
+            default_h: 3,
+            default_config: {},
+        },
+        {
+            name: 'Status Overview',
+            slug: 'status-overview',
+            description: 'Status summary cards',
+            icon: 'document-text',
+            default_w: 4,
+            default_h: 3,
+            default_config: {},
+        },
+    ],
+};
+
+const displayTemplates = Object.keys(props.templates).length > 0 ? props.templates : defaultTemplates;
+
+const getIcon = (slug) => {
+    return iconMap[slug] || iconMap.default;
+};
+
+const handleDragStart = (event, template) => {
+    event.dataTransfer.effectAllowed = 'copy';
+    event.dataTransfer.setData('text/plain', JSON.stringify({ ...template, isTemplate: true }));
+    emit('drag-start', event, { ...template, isTemplate: true });
+};
+</script>
+
+<template>
+  <div class="card-elevated sticky top-24">
+    <h3 class="text-lg font-semibold text-steel-300 mb-4">
+      Widget Toolbox
+    </h3>
+    <p class="text-steel-500 text-sm mb-6">
+      Drag widgets to add them to your dashboard
+    </p>
+
+    <div class="space-y-6">
+      <div
+        v-for="(categoryTemplates, category) in displayTemplates"
+        :key="category"
+      >
+        <h4 class="text-xs font-bold text-steel-400 uppercase tracking-wider mb-3">
+          {{ category }}
+        </h4>
+
+        <div class="space-y-2">
+          <div
+            v-for="template in categoryTemplates"
+            :key="template.slug"
+            draggable="true"
+            class="flex items-center gap-3 p-3 bg-steel-800 rounded-industrial border border-steel-700 cursor-grab hover:border-forge-500 hover:bg-steel-700 transition-all group"
+            @dragstart="handleDragStart($event, template)"
+          >
+            <div class="w-10 h-10 bg-steel-700 rounded flex items-center justify-center group-hover:bg-forge-500/20 transition-colors">
+              <component
+                :is="getIcon(template.slug)"
+                class="w-5 h-5 text-steel-400 group-hover:text-forge-400"
+              />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium text-steel-300">
+                {{ template.name }}
+              </div>
+              <div class="text-xs text-steel-500 truncate">
+                {{ template.description }}
+              </div>
+            </div>
+            <div class="text-xs text-steel-600 font-mono">
+              {{ template.default_w }}x{{ template.default_h }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/ActivityFeedWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/ActivityFeedWidget.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { computed } from 'vue';
+import {
+    BoltIcon,
+    CheckCircleIcon,
+    ExclamationTriangleIcon,
+    ClockIcon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const items = computed(() => {
+    const maxItems = props.config.maxItems || 5;
+    return (props.data?.items || [
+        { id: 1, message: 'Batch B-2024-147 started cutting', time: '2 min ago', status: 'in_progress' },
+        { id: 2, message: 'Load L-2024-089 departed for site', time: '15 min ago', status: 'complete' },
+        { id: 3, message: 'Stock received: 15x W14x30 A992', time: '1 hour ago', status: 'complete' },
+        { id: 4, message: 'Low stock alert: C10x15.3', time: '2 hours ago', status: 'warning' },
+    ]).slice(0, maxItems);
+});
+
+const getStatusIcon = (status) => {
+    switch (status) {
+    case 'in_progress':
+        return BoltIcon;
+    case 'complete':
+        return CheckCircleIcon;
+    case 'warning':
+        return ExclamationTriangleIcon;
+    default:
+        return ClockIcon;
+    }
+};
+
+const getStatusColor = (status) => {
+    switch (status) {
+    case 'in_progress':
+        return 'text-forge-400 bg-forge-500/10 border-forge-500';
+    case 'complete':
+        return 'text-green-400 bg-green-500/10 border-green-500';
+    case 'warning':
+        return 'text-safety-400 bg-safety-500/10 border-safety-500';
+    default:
+        return 'text-steel-400 bg-steel-500/10 border-steel-500';
+    }
+};
+</script>
+
+<template>
+  <div class="h-full overflow-auto space-y-3">
+    <div
+      v-for="item in items"
+      :key="item.id"
+      class="flex items-start gap-3 p-3 bg-steel-800/50 rounded-industrial border border-steel-700 hover:border-steel-600 transition-colors"
+    >
+      <div class="flex-shrink-0">
+        <span
+          class="inline-flex items-center justify-center w-8 h-8 rounded-full border"
+          :class="getStatusColor(item.status)"
+        >
+          <component
+            :is="getStatusIcon(item.status)"
+            class="w-4 h-4"
+          />
+        </span>
+      </div>
+      <div class="flex-1 min-w-0">
+        <p class="text-steel-300 text-sm">
+          {{ item.message }}
+        </p>
+        <p class="text-steel-500 text-xs mt-1 flex items-center gap-1">
+          <ClockIcon class="w-3 h-3" />
+          {{ item.time }}
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-if="items.length === 0"
+      class="h-full flex items-center justify-center text-steel-500 text-sm"
+    >
+      No recent activity
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/ChartWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/ChartWidget.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const chartType = computed(() => {
+    const type = props.widget.widget_type;
+    if (type.includes('pie') || type.includes('doughnut')) return 'pie';
+    if (type.includes('line')) return 'line';
+    return 'bar';
+});
+
+const labels = computed(() => props.data?.labels || ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']);
+const datasets = computed(() => props.data?.datasets || [{ data: [12, 19, 3, 5, 2] }]);
+
+// Simple bar visualization (would use Chart.js in production)
+const maxValue = computed(() => {
+    const allValues = datasets.value.flatMap(d => d.data || []);
+    return Math.max(...allValues, 1);
+});
+</script>
+
+<template>
+  <div class="h-full flex flex-col">
+    <div
+      v-if="config.chartTitle"
+      class="text-sm text-steel-400 mb-3"
+    >
+      {{ config.chartTitle }}
+    </div>
+
+    <!-- Simple Bar Chart Visualization -->
+    <div
+      v-if="chartType === 'bar'"
+      class="flex-1 flex items-end gap-2"
+    >
+      <div
+        v-for="(value, index) in datasets[0]?.data || []"
+        :key="index"
+        class="flex-1 flex flex-col items-center gap-1"
+      >
+        <div
+          class="w-full bg-weld-500/80 rounded-t transition-all hover:bg-weld-400"
+          :style="{ height: `${(value / maxValue) * 100}%`, minHeight: '4px' }"
+        />
+        <span class="text-xs text-steel-500">{{ labels[index] }}</span>
+      </div>
+    </div>
+
+    <!-- Simple Line Chart Visualization -->
+    <div
+      v-else-if="chartType === 'line'"
+      class="flex-1 flex items-end gap-2"
+    >
+      <svg
+        class="w-full h-full"
+        viewBox="0 0 100 50"
+        preserveAspectRatio="none"
+      >
+        <polyline
+          fill="none"
+          stroke="rgba(59, 130, 246, 0.8)"
+          stroke-width="2"
+          :points="datasets[0]?.data?.map((v, i) => `${(i / (datasets[0].data.length - 1)) * 100},${50 - (v / maxValue) * 45}`).join(' ') || '0,50'"
+        />
+        <circle
+          v-for="(value, index) in datasets[0]?.data || []"
+          :key="index"
+          :cx="(index / (datasets[0].data.length - 1)) * 100"
+          :cy="50 - (value / maxValue) * 45"
+          r="3"
+          fill="rgba(59, 130, 246, 1)"
+        />
+      </svg>
+    </div>
+
+    <!-- Simple Pie Chart Visualization -->
+    <div
+      v-else-if="chartType === 'pie'"
+      class="flex-1 flex items-center justify-center"
+    >
+      <div class="relative w-32 h-32">
+        <svg
+          viewBox="0 0 32 32"
+          class="w-full h-full -rotate-90"
+        >
+          <circle
+            v-for="(value, index) in datasets[0]?.data?.slice(0, 4) || [25, 25, 25, 25]"
+            :key="index"
+            r="16"
+            cx="16"
+            cy="16"
+            fill="transparent"
+            :stroke="['#f97316', '#3b82f6', '#22c55e', '#eab308'][index % 4]"
+            stroke-width="32"
+            :stroke-dasharray="`${value} ${100 - value}`"
+            :stroke-dashoffset="datasets[0]?.data?.slice(0, index).reduce((a, b) => a + b, 0) || 0"
+            class="transition-all"
+          />
+        </svg>
+      </div>
+    </div>
+
+    <!-- Legend -->
+    <div
+      v-if="config.showLegend !== false"
+      class="flex flex-wrap gap-3 mt-3 text-xs"
+    >
+      <div
+        v-for="(label, index) in labels.slice(0, 4)"
+        :key="label"
+        class="flex items-center gap-1"
+      >
+        <span
+          class="w-2 h-2 rounded-full"
+          :style="{ backgroundColor: ['#f97316', '#3b82f6', '#22c55e', '#eab308'][index % 4] }"
+        />
+        <span class="text-steel-400">{{ label }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/MetricsCardWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/MetricsCardWidget.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { computed } from 'vue';
+import {
+    FolderOpenIcon,
+    ScaleIcon,
+    ChartBarIcon,
+    TruckIcon,
+    BoltIcon,
+    CubeIcon,
+    ArrowUpIcon,
+    ArrowDownIcon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+// Icon mapping
+const iconMap = {
+    folder: FolderOpenIcon,
+    scale: ScaleIcon,
+    'chart-bar': ChartBarIcon,
+    truck: TruckIcon,
+    bolt: BoltIcon,
+    cube: CubeIcon,
+};
+
+const icon = computed(() => {
+    return iconMap[props.config.icon] || CubeIcon;
+});
+
+const value = computed(() => {
+    return props.data?.value ?? '—';
+});
+
+const formattedValue = computed(() => {
+    const val = value.value;
+    if (typeof val === 'number') {
+        if (props.config.metric === 'total_weight') {
+            return val.toLocaleString();
+        }
+        if (props.config.metric === 'production_progress') {
+            return `${val}%`;
+        }
+        return val.toLocaleString();
+    }
+    return val;
+});
+
+const trend = computed(() => props.data?.trend || null);
+const change = computed(() => props.data?.change || 0);
+
+const unit = computed(() => {
+    if (props.config.metric === 'total_weight') return 'lbs';
+    if (props.config.metric === 'ready_to_ship') return 'loads';
+    return '';
+});
+</script>
+
+<template>
+  <div class="h-full flex flex-col justify-between">
+    <div class="flex items-start justify-between">
+      <div class="flex-1">
+        <div class="text-3xl font-bold text-steel-200">
+          {{ formattedValue }}
+          <span
+            v-if="unit"
+            class="text-sm text-steel-500 font-normal"
+          >{{ unit }}</span>
+        </div>
+
+        <!-- Trend -->
+        <div
+          v-if="trend && change"
+          class="flex items-center gap-1 mt-2"
+          :class="{
+            'text-green-400': trend === 'up',
+            'text-red-400': trend === 'down',
+            'text-steel-500': trend === 'flat',
+          }"
+        >
+          <ArrowUpIcon
+            v-if="trend === 'up'"
+            class="w-4 h-4"
+          />
+          <ArrowDownIcon
+            v-if="trend === 'down'"
+            class="w-4 h-4"
+          />
+          <span class="text-sm">{{ change }}%</span>
+        </div>
+      </div>
+
+      <div class="opacity-30">
+        <component
+          :is="icon"
+          class="w-12 h-12 text-forge-400"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/QuickActionsWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/QuickActionsWidget.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { computed } from 'vue';
+import { Link } from '@inertiajs/vue3';
+import {
+    PlusIcon,
+    ArrowUpTrayIcon,
+    DocumentTextIcon,
+    CubeIcon,
+    TruckIcon,
+    WrenchScrewdriverIcon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+// Icon mapping
+const iconMap = {
+    plus: PlusIcon,
+    upload: ArrowUpTrayIcon,
+    'document-report': DocumentTextIcon,
+    cube: CubeIcon,
+    truck: TruckIcon,
+    wrench: WrenchScrewdriverIcon,
+};
+
+const actions = computed(() => {
+    return props.data?.actions || [
+        { label: 'New Project', route: 'projects.create', icon: 'plus' },
+        { label: 'Import BOM', route: null, icon: 'upload' },
+        { label: 'View Reports', route: 'reports', icon: 'document-report' },
+    ];
+});
+
+const getIcon = (iconName) => {
+    return iconMap[iconName] || CubeIcon;
+};
+
+const getRoute = (routeName) => {
+    try {
+        return routeName ? route(routeName) : '#';
+    } catch (e) {
+        return '#';
+    }
+};
+</script>
+
+<template>
+  <div class="h-full">
+    <div class="grid grid-cols-2 gap-2 h-full">
+      <component
+        :is="action.route ? Link : 'button'"
+        v-for="action in actions"
+        :key="action.label"
+        :href="action.route ? getRoute(action.route) : undefined"
+        class="flex flex-col items-center justify-center gap-2 p-4 bg-steel-800 rounded-industrial border border-steel-700 hover:border-forge-500 hover:bg-steel-700 transition-all text-center"
+      >
+        <component
+          :is="getIcon(action.icon)"
+          class="w-6 h-6 text-forge-400"
+        />
+        <span class="text-sm text-steel-300">{{ action.label }}</span>
+      </component>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/StatusOverviewWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/StatusOverviewWidget.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const statuses = computed(() => {
+    return props.data?.statuses || [
+        { label: 'In Progress', count: 12, color: 'blue' },
+        { label: 'Complete', count: 45, color: 'green' },
+        { label: 'Pending', count: 8, color: 'yellow' },
+    ];
+});
+
+const getColorClass = (color) => {
+    const colors = {
+        blue: 'bg-weld-500 text-weld-100',
+        green: 'bg-green-500 text-green-100',
+        yellow: 'bg-safety-500 text-safety-100',
+        red: 'bg-red-500 text-red-100',
+        orange: 'bg-forge-500 text-forge-100',
+    };
+    return colors[color] || colors.blue;
+};
+
+const total = computed(() => {
+    return statuses.value.reduce((sum, s) => sum + s.count, 0);
+});
+</script>
+
+<template>
+  <div class="h-full flex flex-col">
+    <div class="space-y-3 flex-1">
+      <div
+        v-for="status in statuses"
+        :key="status.label"
+        class="flex items-center justify-between"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            class="w-3 h-3 rounded-full"
+            :class="getColorClass(status.color)"
+          />
+          <span class="text-sm text-steel-300">{{ status.label }}</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-lg font-bold text-steel-200">{{ status.count }}</span>
+          <span class="text-xs text-steel-500">
+            ({{ Math.round((status.count / total) * 100) }}%)
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Progress bar -->
+    <div class="mt-4 pt-4 border-t border-steel-700">
+      <div class="flex h-2 rounded-full overflow-hidden bg-steel-800">
+        <div
+          v-for="status in statuses"
+          :key="status.label"
+          :class="getColorClass(status.color)"
+          :style="{ width: `${(status.count / total) * 100}%` }"
+          class="transition-all"
+        />
+      </div>
+      <div class="mt-2 text-xs text-steel-500 text-right">
+        Total: {{ total }} items
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/Components/UIEditor/widgets/TableWidget.vue
+++ b/resources/js/Components/UIEditor/widgets/TableWidget.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    widget: {
+        type: Object,
+        required: true,
+    },
+    data: {
+        type: Object,
+        default: () => ({}),
+    },
+    config: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const columns = computed(() => props.data?.columns || ['ID', 'Name', 'Status']);
+const rows = computed(() => props.data?.rows || [
+    ['001', 'Sample Item 1', 'Active'],
+    ['002', 'Sample Item 2', 'Pending'],
+    ['003', 'Sample Item 3', 'Complete'],
+]);
+</script>
+
+<template>
+  <div class="h-full overflow-auto">
+    <table class="w-full text-sm">
+      <thead class="sticky top-0 bg-steel-800">
+        <tr>
+          <th
+            v-for="column in columns"
+            :key="column"
+            class="px-3 py-2 text-left text-xs font-semibold text-steel-400 uppercase tracking-wider border-b border-steel-700"
+          >
+            {{ column }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-steel-800">
+        <tr
+          v-for="(row, rowIndex) in rows"
+          :key="rowIndex"
+          class="hover:bg-steel-800/50"
+        >
+          <td
+            v-for="(cell, cellIndex) in row"
+            :key="cellIndex"
+            class="px-3 py-2 text-steel-300 whitespace-nowrap"
+          >
+            {{ cell }}
+          </td>
+        </tr>
+        <tr v-if="rows.length === 0">
+          <td
+            :colspan="columns.length"
+            class="px-3 py-4 text-center text-steel-500"
+          >
+            No data available
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -24,6 +24,7 @@ import {
     CogIcon,
     TruckIcon,
     HomeIcon,
+    PaintBrushIcon,
 } from '@heroicons/vue/24/outline';
 
 const navigation = [
@@ -37,6 +38,7 @@ const navigation = [
     { name: 'Nesting', href: '/nesting', icon: Squares2X2Icon },
     { name: 'Production', href: '/production', icon: CogIcon },
     { name: 'Shipping', href: '/shipping', icon: TruckIcon },
+    { name: 'UI Editor', href: '/ui-editor', icon: PaintBrushIcon },
 ];
 
 const adminNavigation = [

--- a/resources/js/Pages/UIEditor/Create.vue
+++ b/resources/js/Pages/UIEditor/Create.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { useForm, Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import {
+    ArrowLeftIcon,
+    Squares2X2Icon,
+} from '@heroicons/vue/24/outline';
+
+defineProps({
+    widgetTemplates: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+const form = useForm({
+    name: '',
+    description: '',
+    columns: 12,
+    row_height: 80,
+});
+
+const submit = () => {
+    form.post(route('ui-editor.store'));
+};
+</script>
+
+<template>
+  <AppLayout title="Create Dashboard">
+    <!-- Page Header -->
+    <div class="mb-8 flex items-center justify-between">
+      <div class="flex items-center gap-4">
+        <Link
+          :href="route('ui-editor.index')"
+          class="btn-ghost"
+        >
+          <ArrowLeftIcon class="w-5 h-5" />
+        </Link>
+        <div>
+          <h1 class="text-3xl font-bold text-steel-300 text-glow-forge">
+            CREATE DASHBOARD
+          </h1>
+          <p class="text-steel-500 mt-1">
+            Set up your new custom dashboard
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Form -->
+    <div class="max-w-2xl">
+      <form
+        class="card-elevated"
+        @submit.prevent="submit"
+      >
+        <div class="flex items-center gap-4 mb-6 pb-6 border-b border-steel-700">
+          <div class="w-16 h-16 bg-forge-500/20 rounded-industrial flex items-center justify-center">
+            <Squares2X2Icon class="w-8 h-8 text-forge-400" />
+          </div>
+          <div>
+            <h2 class="text-xl font-semibold text-steel-300">
+              Dashboard Details
+            </h2>
+            <p class="text-steel-500 text-sm">
+              Configure your dashboard settings
+            </p>
+          </div>
+        </div>
+
+        <!-- Name -->
+        <div class="mb-6">
+          <label
+            for="name"
+            class="block text-sm font-medium text-steel-300 mb-2"
+          >
+            Dashboard Name *
+          </label>
+          <input
+            id="name"
+            v-model="form.name"
+            type="text"
+            class="input w-full"
+            placeholder="My Dashboard"
+            required
+          >
+          <p
+            v-if="form.errors.name"
+            class="mt-1 text-sm text-red-400"
+          >
+            {{ form.errors.name }}
+          </p>
+        </div>
+
+        <!-- Description -->
+        <div class="mb-6">
+          <label
+            for="description"
+            class="block text-sm font-medium text-steel-300 mb-2"
+          >
+            Description
+          </label>
+          <textarea
+            id="description"
+            v-model="form.description"
+            class="input w-full"
+            rows="3"
+            placeholder="Optional description for this dashboard"
+          />
+          <p
+            v-if="form.errors.description"
+            class="mt-1 text-sm text-red-400"
+          >
+            {{ form.errors.description }}
+          </p>
+        </div>
+
+        <!-- Grid Settings -->
+        <div class="grid grid-cols-2 gap-6 mb-6">
+          <div>
+            <label
+              for="columns"
+              class="block text-sm font-medium text-steel-300 mb-2"
+            >
+              Grid Columns
+            </label>
+            <select
+              id="columns"
+              v-model="form.columns"
+              class="input w-full"
+            >
+              <option :value="6">
+                6 Columns
+              </option>
+              <option :value="12">
+                12 Columns (Recommended)
+              </option>
+              <option :value="24">
+                24 Columns
+              </option>
+            </select>
+            <p class="mt-1 text-xs text-steel-500">
+              More columns = finer positioning control
+            </p>
+          </div>
+
+          <div>
+            <label
+              for="row_height"
+              class="block text-sm font-medium text-steel-300 mb-2"
+            >
+              Row Height (px)
+            </label>
+            <input
+              id="row_height"
+              v-model.number="form.row_height"
+              type="number"
+              class="input w-full"
+              min="40"
+              max="200"
+            >
+            <p class="mt-1 text-xs text-steel-500">
+              Height of each grid row
+            </p>
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-end gap-3 pt-6 border-t border-steel-700">
+          <Link
+            :href="route('ui-editor.index')"
+            class="btn-secondary"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            class="btn-primary"
+            :disabled="form.processing"
+          >
+            <span v-if="form.processing">Creating...</span>
+            <span v-else>Create Dashboard</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </AppLayout>
+</template>

--- a/resources/js/Pages/UIEditor/Edit.vue
+++ b/resources/js/Pages/UIEditor/Edit.vue
@@ -1,0 +1,484 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { Link, router } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import WidgetToolbox from '@/Components/UIEditor/WidgetToolbox.vue';
+import WidgetCard from '@/Components/UIEditor/WidgetCard.vue';
+import WidgetConfigPanel from '@/Components/UIEditor/WidgetConfigPanel.vue';
+import {
+    ArrowLeftIcon,
+    Cog6ToothIcon,
+    EyeIcon,
+    CheckIcon,
+    XMarkIcon,
+    Squares2X2Icon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    dashboard: {
+        type: Object,
+        required: true,
+    },
+    widgets: {
+        type: Array,
+        default: () => [],
+    },
+    layout: {
+        type: Array,
+        default: () => [],
+    },
+    widgetTemplates: {
+        type: Object,
+        default: () => ({}),
+    },
+});
+
+// State
+const localWidgets = ref([...props.widgets]);
+const localLayout = ref([...props.layout]);
+const selectedWidget = ref(null);
+const isDragging = ref(false);
+const draggedWidget = ref(null);
+const hasUnsavedChanges = ref(false);
+const isSaving = ref(false);
+const showSettings = ref(false);
+const gridRef = ref(null);
+
+// Computed
+const gridStyle = computed(() => ({
+    display: 'grid',
+    gridTemplateColumns: `repeat(${props.dashboard.columns}, 1fr)`,
+    gap: '8px',
+    minHeight: '600px',
+}));
+
+// Get widget position from layout
+const getWidgetStyle = (widget) => {
+    const layoutItem = localLayout.value.find(l => l.i === widget.id);
+    if (!layoutItem) return {};
+
+    return {
+        gridColumn: `${layoutItem.x + 1} / span ${layoutItem.w}`,
+        gridRow: `${layoutItem.y + 1} / span ${layoutItem.h}`,
+        minHeight: `${layoutItem.h * props.dashboard.row_height}px`,
+    };
+};
+
+// Drag and drop handlers
+const handleDragStart = (event, widget) => {
+    isDragging.value = true;
+    draggedWidget.value = widget;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', JSON.stringify(widget));
+};
+
+const handleDragEnd = () => {
+    isDragging.value = false;
+    draggedWidget.value = null;
+};
+
+const handleDragOver = (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+};
+
+const handleDrop = (event) => {
+    event.preventDefault();
+
+    const data = event.dataTransfer.getData('text/plain');
+    if (!data) return;
+
+    const widget = JSON.parse(data);
+
+    // Calculate drop position
+    const rect = gridRef.value.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+
+    const colWidth = rect.width / props.dashboard.columns;
+    const newX = Math.floor(x / colWidth);
+    const newY = Math.floor(y / props.dashboard.row_height);
+
+    // If it's a new widget from toolbox
+    if (widget.isTemplate) {
+        addWidgetFromTemplate(widget, newX, newY);
+    } else {
+        // Move existing widget
+        updateWidgetPosition(widget.id, newX, newY);
+    }
+
+    isDragging.value = false;
+    draggedWidget.value = null;
+};
+
+// Add new widget from template
+const addWidgetFromTemplate = async (template, x, y) => {
+    try {
+        const response = await fetch(route('ui-editor.widgets.store', props.dashboard.id), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({
+                widget_type: template.slug,
+                title: template.name,
+                grid_x: Math.max(0, Math.min(x, props.dashboard.columns - template.default_w)),
+                grid_y: y,
+                grid_w: template.default_w,
+                grid_h: template.default_h,
+                config: template.default_config || {},
+            }),
+        });
+
+        const data = await response.json();
+        if (data.success) {
+            localWidgets.value.push(data.widget);
+            localLayout.value.push({
+                i: data.widget.id,
+                x: data.widget.grid_x,
+                y: data.widget.grid_y,
+                w: data.widget.grid_w,
+                h: data.widget.grid_h,
+                minW: data.widget.min_w,
+                minH: data.widget.min_h,
+            });
+        }
+    } catch (error) {
+        console.error('Failed to add widget:', error);
+    }
+};
+
+// Update widget position
+const updateWidgetPosition = (widgetId, newX, newY) => {
+    const layoutIndex = localLayout.value.findIndex(l => l.i === widgetId);
+    if (layoutIndex === -1) return;
+
+    const item = localLayout.value[layoutIndex];
+    const maxX = props.dashboard.columns - item.w;
+
+    localLayout.value[layoutIndex] = {
+        ...item,
+        x: Math.max(0, Math.min(newX, maxX)),
+        y: Math.max(0, newY),
+    };
+
+    hasUnsavedChanges.value = true;
+};
+
+// Resize widget
+const resizeWidget = (widgetId, newW, newH) => {
+    const layoutIndex = localLayout.value.findIndex(l => l.i === widgetId);
+    if (layoutIndex === -1) return;
+
+    const item = localLayout.value[layoutIndex];
+
+    localLayout.value[layoutIndex] = {
+        ...item,
+        w: Math.max(item.minW || 2, Math.min(newW, props.dashboard.columns - item.x)),
+        h: Math.max(item.minH || 2, newH),
+    };
+
+    hasUnsavedChanges.value = true;
+};
+
+// Remove widget
+const removeWidget = async (widget) => {
+    if (!confirm('Remove this widget from the dashboard?')) return;
+
+    try {
+        const response = await fetch(route('ui-editor.widgets.destroy', [props.dashboard.id, widget.id]), {
+            method: 'DELETE',
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'Accept': 'application/json',
+            },
+        });
+
+        const data = await response.json();
+        if (data.success) {
+            localWidgets.value = localWidgets.value.filter(w => w.id !== widget.id);
+            localLayout.value = localLayout.value.filter(l => l.i !== widget.id);
+            if (selectedWidget.value?.id === widget.id) {
+                selectedWidget.value = null;
+            }
+        }
+    } catch (error) {
+        console.error('Failed to remove widget:', error);
+    }
+};
+
+// Save layout
+const saveLayout = async () => {
+    isSaving.value = true;
+
+    try {
+        const response = await fetch(route('ui-editor.layout.update', props.dashboard.id), {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ layout: localLayout.value }),
+        });
+
+        const data = await response.json();
+        if (data.success) {
+            hasUnsavedChanges.value = false;
+        }
+    } catch (error) {
+        console.error('Failed to save layout:', error);
+    } finally {
+        isSaving.value = false;
+    }
+};
+
+// Select widget for configuration
+const selectWidget = (widget) => {
+    selectedWidget.value = widget;
+};
+
+// Update widget config
+const updateWidgetConfig = async (widget, config) => {
+    try {
+        const response = await fetch(route('ui-editor.widgets.update', [props.dashboard.id, widget.id]), {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify(config),
+        });
+
+        const data = await response.json();
+        if (data.success) {
+            const index = localWidgets.value.findIndex(w => w.id === widget.id);
+            if (index !== -1) {
+                localWidgets.value[index] = data.widget;
+            }
+            selectedWidget.value = data.widget;
+        }
+    } catch (error) {
+        console.error('Failed to update widget:', error);
+    }
+};
+
+// Warn before leaving with unsaved changes
+const handleBeforeUnload = (event) => {
+    if (hasUnsavedChanges.value) {
+        event.preventDefault();
+        event.returnValue = '';
+    }
+};
+
+onMounted(() => {
+    window.addEventListener('beforeunload', handleBeforeUnload);
+});
+
+onUnmounted(() => {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+});
+</script>
+
+<template>
+  <AppLayout title="Edit Dashboard">
+    <!-- Header -->
+    <div class="mb-6 flex items-center justify-between">
+      <div class="flex items-center gap-4">
+        <Link
+          :href="route('ui-editor.index')"
+          class="btn-ghost"
+        >
+          <ArrowLeftIcon class="w-5 h-5" />
+        </Link>
+        <div>
+          <h1 class="text-2xl font-bold text-steel-300">
+            {{ dashboard.name }}
+          </h1>
+          <p class="text-steel-500 text-sm">
+            Drag widgets from the toolbox to build your dashboard
+          </p>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <!-- Unsaved indicator -->
+        <span
+          v-if="hasUnsavedChanges"
+          class="text-safety-400 text-sm flex items-center gap-1"
+        >
+          <span class="w-2 h-2 bg-safety-400 rounded-full animate-pulse" />
+          Unsaved changes
+        </span>
+
+        <button
+          class="btn-ghost"
+          @click="showSettings = !showSettings"
+        >
+          <Cog6ToothIcon class="w-5 h-5" />
+        </button>
+
+        <Link
+          :href="route('ui-editor.show', dashboard.id)"
+          class="btn-secondary"
+        >
+          <EyeIcon class="w-5 h-5" />
+          <span>Preview</span>
+        </Link>
+
+        <button
+          class="btn-primary"
+          :disabled="!hasUnsavedChanges || isSaving"
+          @click="saveLayout"
+        >
+          <CheckIcon class="w-5 h-5" />
+          <span>{{ isSaving ? 'Saving...' : 'Save Layout' }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Main Editor Area -->
+    <div class="flex gap-6">
+      <!-- Widget Toolbox (Left Sidebar) -->
+      <div class="w-64 flex-shrink-0">
+        <WidgetToolbox
+          :templates="widgetTemplates"
+          @drag-start="handleDragStart"
+        />
+      </div>
+
+      <!-- Grid Editor -->
+      <div class="flex-1">
+        <div
+          ref="gridRef"
+          class="bg-steel-800/50 rounded-industrial border-2 border-dashed border-steel-700 p-4 min-h-[600px] relative"
+          :class="{ 'border-forge-500 bg-forge-500/5': isDragging }"
+          :style="gridStyle"
+          @dragover="handleDragOver"
+          @drop="handleDrop"
+        >
+          <!-- Grid Overlay (for visual guidance) -->
+          <div
+            v-if="isDragging"
+            class="absolute inset-0 pointer-events-none"
+          >
+            <div
+              class="w-full h-full grid opacity-20"
+              :style="{ gridTemplateColumns: `repeat(${dashboard.columns}, 1fr)` }"
+            >
+              <div
+                v-for="i in dashboard.columns"
+                :key="i"
+                class="border-r border-steel-600 h-full"
+              />
+            </div>
+          </div>
+
+          <!-- Widgets -->
+          <WidgetCard
+            v-for="widget in localWidgets"
+            :key="widget.id"
+            :widget="widget"
+            :style="getWidgetStyle(widget)"
+            :is-selected="selectedWidget?.id === widget.id"
+            :is-editing="true"
+            @select="selectWidget(widget)"
+            @remove="removeWidget(widget)"
+            @drag-start="handleDragStart($event, widget)"
+            @drag-end="handleDragEnd"
+            @resize="(w, h) => resizeWidget(widget.id, w, h)"
+          />
+
+          <!-- Empty State -->
+          <div
+            v-if="localWidgets.length === 0"
+            class="absolute inset-0 flex items-center justify-center col-span-full"
+          >
+            <div class="text-center">
+              <Squares2X2Icon class="w-16 h-16 text-steel-600 mx-auto mb-4" />
+              <p class="text-steel-500">
+                Drag widgets here to build your dashboard
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Widget Config Panel (Right Sidebar) -->
+      <div
+        v-if="selectedWidget"
+        class="w-80 flex-shrink-0"
+      >
+        <WidgetConfigPanel
+          :widget="selectedWidget"
+          @update="(config) => updateWidgetConfig(selectedWidget, config)"
+          @close="selectedWidget = null"
+        />
+      </div>
+    </div>
+
+    <!-- Settings Modal -->
+    <div
+      v-if="showSettings"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div class="card-elevated w-full max-w-md">
+        <div class="flex items-center justify-between mb-6">
+          <h2 class="text-xl font-semibold text-steel-300">
+            Dashboard Settings
+          </h2>
+          <button
+            class="btn-ghost"
+            @click="showSettings = false"
+          >
+            <XMarkIcon class="w-5 h-5" />
+          </button>
+        </div>
+
+        <form @submit.prevent="router.put(route('ui-editor.update', dashboard.id), { name: dashboard.name, description: dashboard.description })">
+          <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-steel-300 mb-2">
+                Name
+              </label>
+              <input
+                v-model="dashboard.name"
+                type="text"
+                class="input w-full"
+              >
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-steel-300 mb-2">
+                Description
+              </label>
+              <textarea
+                v-model="dashboard.description"
+                class="input w-full"
+                rows="3"
+              />
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-3 mt-6 pt-6 border-t border-steel-700">
+            <button
+              type="button"
+              class="btn-secondary"
+              @click="showSettings = false"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="btn-primary"
+            >
+              Save Settings
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/resources/js/Pages/UIEditor/Index.vue
+++ b/resources/js/Pages/UIEditor/Index.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { Link, router } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import {
+    PlusIcon,
+    PencilSquareIcon,
+    TrashIcon,
+    DocumentDuplicateIcon,
+    StarIcon,
+    ShareIcon,
+    Squares2X2Icon,
+} from '@heroicons/vue/24/outline';
+import { StarIcon as StarSolidIcon } from '@heroicons/vue/24/solid';
+
+const props = defineProps({
+    dashboards: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const setDefault = (dashboard) => {
+    router.post(route('ui-editor.set-default', dashboard.id), {}, {
+        preserveScroll: true,
+    });
+};
+
+const deleteDashboard = (dashboard) => {
+    if (confirm(`Are you sure you want to delete "${dashboard.name}"?`)) {
+        router.delete(route('ui-editor.destroy', dashboard.id));
+    }
+};
+
+const duplicateDashboard = (dashboard) => {
+    router.post(route('ui-editor.duplicate', dashboard.id), {
+        name: `${dashboard.name} (Copy)`,
+    });
+};
+</script>
+
+<template>
+  <AppLayout title="Dashboard Builder">
+    <!-- Page Header -->
+    <div class="mb-8 flex items-center justify-between">
+      <div>
+        <h1 class="text-3xl font-bold text-steel-300 text-glow-forge">
+          DASHBOARD BUILDER
+        </h1>
+        <p class="text-steel-500 mt-1">
+          Create and customize your dashboard layouts
+        </p>
+      </div>
+      <div class="flex gap-3">
+        <Link
+          :href="route('ui-editor.create')"
+          class="btn-primary"
+        >
+          <PlusIcon class="w-5 h-5" />
+          <span>New Dashboard</span>
+        </Link>
+      </div>
+    </div>
+
+    <!-- Dashboards Grid -->
+    <div
+      v-if="dashboards.length > 0"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    >
+      <div
+        v-for="dashboard in dashboards"
+        :key="dashboard.id"
+        class="card-elevated group hover:border-forge-500/50 transition-all"
+      >
+        <!-- Dashboard Preview -->
+        <div class="relative h-40 bg-steel-800 rounded-t-industrial mb-4 overflow-hidden">
+          <div class="absolute inset-0 grid grid-cols-12 gap-1 p-2 opacity-30">
+            <div
+              v-for="widget in dashboard.widgets?.slice(0, 6) || []"
+              :key="widget.id"
+              class="bg-steel-600 rounded"
+              :style="{
+                gridColumn: `span ${Math.min(widget.grid_w, 4)}`,
+                gridRow: `span ${Math.min(widget.grid_h, 2)}`,
+              }"
+            />
+          </div>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <Squares2X2Icon class="w-16 h-16 text-steel-600" />
+          </div>
+
+          <!-- Default badge -->
+          <div
+            v-if="dashboard.is_default"
+            class="absolute top-2 right-2 px-2 py-1 bg-forge-500 text-white text-xs font-bold rounded"
+          >
+            DEFAULT
+          </div>
+
+          <!-- Shared badge -->
+          <div
+            v-if="dashboard.is_shared"
+            class="absolute top-2 left-2 px-2 py-1 bg-weld-500 text-white text-xs font-bold rounded flex items-center gap-1"
+          >
+            <ShareIcon class="w-3 h-3" />
+            SHARED
+          </div>
+        </div>
+
+        <!-- Dashboard Info -->
+        <div class="px-4 pb-4">
+          <h3 class="text-lg font-semibold text-steel-300 mb-1">
+            {{ dashboard.name }}
+          </h3>
+          <p class="text-steel-500 text-sm mb-4 line-clamp-2">
+            {{ dashboard.description || 'No description' }}
+          </p>
+
+          <div class="flex items-center justify-between text-xs text-steel-500 mb-4">
+            <span>{{ dashboard.widgets?.length || 0 }} widgets</span>
+            <span>{{ dashboard.columns }} columns</span>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex items-center gap-2">
+            <Link
+              :href="route('ui-editor.edit', dashboard.id)"
+              class="btn-primary flex-1 text-sm"
+            >
+              <PencilSquareIcon class="w-4 h-4" />
+              <span>Edit</span>
+            </Link>
+            <Link
+              :href="route('ui-editor.show', dashboard.id)"
+              class="btn-secondary flex-1 text-sm"
+            >
+              <span>View</span>
+            </Link>
+          </div>
+
+          <!-- Secondary Actions -->
+          <div class="flex items-center gap-1 mt-3 pt-3 border-t border-steel-700">
+            <button
+              class="btn-ghost text-xs flex-1"
+              :class="{ 'text-forge-400': dashboard.is_default }"
+              :title="dashboard.is_default ? 'Default Dashboard' : 'Set as Default'"
+              @click="setDefault(dashboard)"
+            >
+              <component
+                :is="dashboard.is_default ? StarSolidIcon : StarIcon"
+                class="w-4 h-4"
+              />
+            </button>
+            <button
+              class="btn-ghost text-xs flex-1"
+              title="Duplicate"
+              @click="duplicateDashboard(dashboard)"
+            >
+              <DocumentDuplicateIcon class="w-4 h-4" />
+            </button>
+            <button
+              class="btn-ghost text-xs flex-1 text-red-400 hover:text-red-300"
+              title="Delete"
+              @click="deleteDashboard(dashboard)"
+            >
+              <TrashIcon class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div
+      v-else
+      class="card-elevated text-center py-16"
+    >
+      <Squares2X2Icon class="w-16 h-16 text-steel-600 mx-auto mb-4" />
+      <h3 class="text-xl font-semibold text-steel-300 mb-2">
+        No Dashboards Yet
+      </h3>
+      <p class="text-steel-500 mb-6">
+        Create your first custom dashboard to get started.
+      </p>
+      <Link
+        :href="route('ui-editor.create')"
+        class="btn-primary"
+      >
+        <PlusIcon class="w-5 h-5" />
+        <span>Create Dashboard</span>
+      </Link>
+    </div>
+  </AppLayout>
+</template>

--- a/resources/js/Pages/UIEditor/Show.vue
+++ b/resources/js/Pages/UIEditor/Show.vue
@@ -1,0 +1,132 @@
+<script setup>
+import { computed } from 'vue';
+import { Link } from '@inertiajs/vue3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import WidgetCard from '@/Components/UIEditor/WidgetCard.vue';
+import {
+    ArrowLeftIcon,
+    PencilSquareIcon,
+    ArrowPathIcon,
+} from '@heroicons/vue/24/outline';
+
+const props = defineProps({
+    dashboard: {
+        type: Object,
+        required: true,
+    },
+    widgets: {
+        type: Array,
+        default: () => [],
+    },
+    layout: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+// Computed grid style
+const gridStyle = computed(() => ({
+    display: 'grid',
+    gridTemplateColumns: `repeat(${props.dashboard.columns}, 1fr)`,
+    gap: '16px',
+}));
+
+// Get widget position from layout
+const getWidgetStyle = (widget) => {
+    const layoutItem = props.layout.find(l => l.i === widget.id);
+    if (!layoutItem) return {};
+
+    return {
+        gridColumn: `${layoutItem.x + 1} / span ${layoutItem.w}`,
+        gridRow: `${layoutItem.y + 1} / span ${layoutItem.h}`,
+        minHeight: `${layoutItem.h * props.dashboard.row_height}px`,
+    };
+};
+
+// Refresh widget data
+const refreshWidget = async (widget) => {
+    try {
+        const response = await fetch(route('ui-editor.widgets.data', [props.dashboard.id, widget.id]));
+        const data = await response.json();
+        widget.data = data.data;
+    } catch (error) {
+        console.error('Failed to refresh widget:', error);
+    }
+};
+</script>
+
+<template>
+  <AppLayout :title="dashboard.name">
+    <!-- Header -->
+    <div class="mb-6 flex items-center justify-between">
+      <div class="flex items-center gap-4">
+        <Link
+          :href="route('ui-editor.index')"
+          class="btn-ghost"
+        >
+          <ArrowLeftIcon class="w-5 h-5" />
+        </Link>
+        <div>
+          <h1 class="text-2xl font-bold text-steel-300">
+            {{ dashboard.name }}
+          </h1>
+          <p
+            v-if="dashboard.description"
+            class="text-steel-500 text-sm"
+          >
+            {{ dashboard.description }}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button
+          class="btn-ghost"
+          title="Refresh All"
+          @click="widgets.forEach(refreshWidget)"
+        >
+          <ArrowPathIcon class="w-5 h-5" />
+        </button>
+        <Link
+          :href="route('ui-editor.edit', dashboard.id)"
+          class="btn-primary"
+        >
+          <PencilSquareIcon class="w-5 h-5" />
+          <span>Edit</span>
+        </Link>
+      </div>
+    </div>
+
+    <!-- Dashboard Grid -->
+    <div
+      :style="gridStyle"
+      class="min-h-[400px]"
+    >
+      <WidgetCard
+        v-for="widget in widgets"
+        :key="widget.id"
+        :widget="widget"
+        :style="getWidgetStyle(widget)"
+        :is-editing="false"
+        @refresh="refreshWidget(widget)"
+      />
+    </div>
+
+    <!-- Empty State -->
+    <div
+      v-if="widgets.length === 0"
+      class="card-elevated text-center py-16"
+    >
+      <p class="text-steel-500 mb-4">
+        This dashboard has no widgets yet.
+      </p>
+      <Link
+        :href="route('ui-editor.edit', dashboard.id)"
+        class="btn-primary"
+      >
+        <PencilSquareIcon class="w-5 h-5" />
+        <span>Add Widgets</span>
+      </Link>
+    </div>
+  </AppLayout>
+</template>

--- a/resources/js/stores/uiEditor.js
+++ b/resources/js/stores/uiEditor.js
@@ -1,0 +1,174 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+
+export const useUIEditorStore = defineStore('uiEditor', () => {
+    // State
+    const dashboards = ref([]);
+    const currentDashboard = ref(null);
+    const widgets = ref([]);
+    const layout = ref([]);
+    const selectedWidgetId = ref(null);
+    const isDragging = ref(false);
+    const hasUnsavedChanges = ref(false);
+    const isLoading = ref(false);
+    const error = ref(null);
+
+    // Getters
+    const selectedWidget = computed(() => {
+        if (!selectedWidgetId.value) return null;
+        return widgets.value.find(w => w.id === selectedWidgetId.value) || null;
+    });
+
+    const widgetCount = computed(() => widgets.value.length);
+
+    const getWidgetLayout = computed(() => (widgetId) => {
+        return layout.value.find(l => l.i === widgetId);
+    });
+
+    // Actions
+    function setDashboards(data) {
+        dashboards.value = data;
+    }
+
+    function setCurrentDashboard(dashboard) {
+        currentDashboard.value = dashboard;
+    }
+
+    function setWidgets(data) {
+        widgets.value = data;
+    }
+
+    function setLayout(data) {
+        layout.value = data;
+    }
+
+    function selectWidget(widgetId) {
+        selectedWidgetId.value = widgetId;
+    }
+
+    function deselectWidget() {
+        selectedWidgetId.value = null;
+    }
+
+    function setDragging(value) {
+        isDragging.value = value;
+    }
+
+    function markAsChanged() {
+        hasUnsavedChanges.value = true;
+    }
+
+    function markAsSaved() {
+        hasUnsavedChanges.value = false;
+    }
+
+    function addWidget(widget) {
+        widgets.value.push(widget);
+        layout.value.push({
+            i: widget.id,
+            x: widget.grid_x,
+            y: widget.grid_y,
+            w: widget.grid_w,
+            h: widget.grid_h,
+            minW: widget.min_w,
+            minH: widget.min_h,
+        });
+        markAsChanged();
+    }
+
+    function updateWidget(widgetId, data) {
+        const index = widgets.value.findIndex(w => w.id === widgetId);
+        if (index !== -1) {
+            widgets.value[index] = { ...widgets.value[index], ...data };
+            markAsChanged();
+        }
+    }
+
+    function removeWidget(widgetId) {
+        widgets.value = widgets.value.filter(w => w.id !== widgetId);
+        layout.value = layout.value.filter(l => l.i !== widgetId);
+        if (selectedWidgetId.value === widgetId) {
+            deselectWidget();
+        }
+        markAsChanged();
+    }
+
+    function updateWidgetPosition(widgetId, position) {
+        const layoutIndex = layout.value.findIndex(l => l.i === widgetId);
+        if (layoutIndex !== -1) {
+            layout.value[layoutIndex] = {
+                ...layout.value[layoutIndex],
+                x: position.x,
+                y: position.y,
+                w: position.w,
+                h: position.h,
+            };
+            markAsChanged();
+        }
+    }
+
+    function updateLayout(newLayout) {
+        layout.value = newLayout;
+        markAsChanged();
+    }
+
+    function setLoading(value) {
+        isLoading.value = value;
+    }
+
+    function setError(err) {
+        error.value = err;
+    }
+
+    function clearError() {
+        error.value = null;
+    }
+
+    function reset() {
+        currentDashboard.value = null;
+        widgets.value = [];
+        layout.value = [];
+        selectedWidgetId.value = null;
+        isDragging.value = false;
+        hasUnsavedChanges.value = false;
+        error.value = null;
+    }
+
+    return {
+        // State
+        dashboards,
+        currentDashboard,
+        widgets,
+        layout,
+        selectedWidgetId,
+        isDragging,
+        hasUnsavedChanges,
+        isLoading,
+        error,
+
+        // Getters
+        selectedWidget,
+        widgetCount,
+        getWidgetLayout,
+
+        // Actions
+        setDashboards,
+        setCurrentDashboard,
+        setWidgets,
+        setLayout,
+        selectWidget,
+        deselectWidget,
+        setDragging,
+        markAsChanged,
+        markAsSaved,
+        addWidget,
+        updateWidget,
+        removeWidget,
+        updateWidgetPosition,
+        updateLayout,
+        setLoading,
+        setError,
+        clearError,
+        reset,
+    };
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\RoutingController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\ShippingController;
 use App\Http\Controllers\TimeEntryController;
+use App\Http\Controllers\UIEditorController;
 use Illuminate\Support\Facades\Route;
 
 // Root route - redirect to dashboard if authenticated, otherwise to login
@@ -106,6 +107,26 @@ Route::middleware('auth')->group(function () {
     Route::get('/reports/projects/{project}/bom', [ReportController::class, 'projectBom'])->name('reports.project.bom');
     Route::get('/reports/projects/{project}/bom/csv', [ReportController::class, 'projectBomCsv'])->name('reports.project.bom.csv');
     Route::get('/reports/projects/{project}/bom/pdf', [ReportController::class, 'projectBomPdf'])->name('reports.project.bom.pdf');
+
+    // UI Editor / Dashboard Builder Routes
+    Route::prefix('ui-editor')->name('ui-editor.')->group(function () {
+        Route::get('/', [UIEditorController::class, 'index'])->name('index');
+        Route::get('/create', [UIEditorController::class, 'create'])->name('create');
+        Route::post('/', [UIEditorController::class, 'store'])->name('store');
+        Route::get('/{dashboard}', [UIEditorController::class, 'show'])->name('show');
+        Route::get('/{dashboard}/edit', [UIEditorController::class, 'edit'])->name('edit');
+        Route::put('/{dashboard}', [UIEditorController::class, 'update'])->name('update');
+        Route::delete('/{dashboard}', [UIEditorController::class, 'destroy'])->name('destroy');
+        Route::post('/{dashboard}/set-default', [UIEditorController::class, 'setDefault'])->name('set-default');
+        Route::post('/{dashboard}/duplicate', [UIEditorController::class, 'duplicate'])->name('duplicate');
+
+        // Widget management (JSON responses for AJAX)
+        Route::post('/{dashboard}/widgets', [UIEditorController::class, 'addWidget'])->name('widgets.store');
+        Route::put('/{dashboard}/widgets/{widget}', [UIEditorController::class, 'updateWidget'])->name('widgets.update');
+        Route::delete('/{dashboard}/widgets/{widget}', [UIEditorController::class, 'removeWidget'])->name('widgets.destroy');
+        Route::put('/{dashboard}/layout', [UIEditorController::class, 'updateLayout'])->name('layout.update');
+        Route::get('/{dashboard}/widgets/{widget}/data', [UIEditorController::class, 'getWidgetData'])->name('widgets.data');
+    });
 });
 
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {

--- a/tests/Feature/UIEditorTest.php
+++ b/tests/Feature/UIEditorTest.php
@@ -1,0 +1,287 @@
+<?php
+
+use App\Models\Dashboard;
+use App\Models\DashboardWidget;
+use App\Models\User;
+use App\Services\UIEditorService;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+describe('UIEditorController', function () {
+    it('displays the dashboard builder index', function () {
+        $response = $this->get(route('ui-editor.index'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('UIEditor/Index'));
+    });
+
+    it('displays the create dashboard form', function () {
+        $response = $this->get(route('ui-editor.create'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('UIEditor/Create'));
+    });
+
+    it('creates a new dashboard', function () {
+        $response = $this->post(route('ui-editor.store'), [
+            'name' => 'Test Dashboard',
+            'description' => 'A test dashboard',
+            'columns' => 12,
+            'row_height' => 80,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('dashboards', [
+            'name' => 'Test Dashboard',
+            'user_id' => $this->user->id,
+        ]);
+    });
+
+    it('validates dashboard name is required', function () {
+        $response = $this->post(route('ui-editor.store'), [
+            'description' => 'A test dashboard',
+        ]);
+
+        $response->assertSessionHasErrors('name');
+    });
+
+    it('displays a dashboard', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->get(route('ui-editor.show', $dashboard));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('UIEditor/Show')
+            ->has('dashboard')
+        );
+    });
+
+    it('displays the dashboard editor', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->get(route('ui-editor.edit', $dashboard));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('UIEditor/Edit')
+            ->has('dashboard')
+            ->has('widgetTemplates')
+        );
+    });
+
+    it('updates a dashboard', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->put(route('ui-editor.update', $dashboard), [
+            'name' => 'Updated Dashboard',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('dashboards', [
+            'id' => $dashboard->id,
+            'name' => 'Updated Dashboard',
+        ]);
+    });
+
+    it('deletes a dashboard', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->delete(route('ui-editor.destroy', $dashboard));
+
+        $response->assertRedirect(route('ui-editor.index'));
+        $this->assertSoftDeleted('dashboards', ['id' => $dashboard->id]);
+    });
+
+    it('prevents unauthorized users from editing others dashboards', function () {
+        $otherUser = User::factory()->create();
+        $dashboard = Dashboard::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->get(route('ui-editor.edit', $dashboard));
+
+        $response->assertForbidden();
+    });
+
+    it('allows viewing shared dashboards', function () {
+        $otherUser = User::factory()->create();
+        $dashboard = Dashboard::factory()->create([
+            'user_id' => $otherUser->id,
+            'is_shared' => true,
+        ]);
+
+        $response = $this->get(route('ui-editor.show', $dashboard));
+
+        $response->assertStatus(200);
+    });
+});
+
+describe('Widget Management', function () {
+    it('adds a widget to a dashboard', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->postJson(route('ui-editor.widgets.store', $dashboard), [
+            'widget_type' => 'metrics-card',
+            'title' => 'Test Widget',
+            'grid_x' => 0,
+            'grid_y' => 0,
+            'grid_w' => 3,
+            'grid_h' => 2,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        $this->assertDatabaseHas('dashboard_widgets', [
+            'dashboard_id' => $dashboard->id,
+            'widget_type' => 'metrics-card',
+            'title' => 'Test Widget',
+        ]);
+    });
+
+    it('updates a widget configuration', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+        $widget = DashboardWidget::factory()->create(['dashboard_id' => $dashboard->id]);
+
+        $response = $this->putJson(route('ui-editor.widgets.update', [$dashboard, $widget]), [
+            'title' => 'Updated Widget',
+            'config' => ['metric' => 'total_weight'],
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        $this->assertDatabaseHas('dashboard_widgets', [
+            'id' => $widget->id,
+            'title' => 'Updated Widget',
+        ]);
+    });
+
+    it('removes a widget from a dashboard', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+        $widget = DashboardWidget::factory()->create(['dashboard_id' => $dashboard->id]);
+
+        $response = $this->deleteJson(route('ui-editor.widgets.destroy', [$dashboard, $widget]));
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+        $this->assertDatabaseMissing('dashboard_widgets', ['id' => $widget->id]);
+    });
+
+    it('updates the layout of all widgets', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+        $widget1 = DashboardWidget::factory()->create([
+            'dashboard_id' => $dashboard->id,
+            'grid_x' => 0,
+            'grid_y' => 0,
+        ]);
+        $widget2 = DashboardWidget::factory()->create([
+            'dashboard_id' => $dashboard->id,
+            'grid_x' => 3,
+            'grid_y' => 0,
+        ]);
+
+        $response = $this->putJson(route('ui-editor.layout.update', $dashboard), [
+            'layout' => [
+                ['i' => $widget1->id, 'x' => 0, 'y' => 2, 'w' => 4, 'h' => 3],
+                ['i' => $widget2->id, 'x' => 4, 'y' => 2, 'w' => 4, 'h' => 3],
+            ],
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['success' => true]);
+
+        $widget1->refresh();
+        expect($widget1->grid_y)->toBe(2);
+        expect($widget1->grid_w)->toBe(4);
+    });
+});
+
+describe('UIEditorService', function () {
+    it('creates a dashboard for a user', function () {
+        $service = app(UIEditorService::class);
+
+        $dashboard = $service->createDashboard($this->user, [
+            'name' => 'Service Test Dashboard',
+            'description' => 'Created via service',
+        ]);
+
+        expect($dashboard)->toBeInstanceOf(Dashboard::class);
+        expect($dashboard->name)->toBe('Service Test Dashboard');
+        expect($dashboard->user_id)->toBe($this->user->id);
+    });
+
+    it('duplicates a dashboard', function () {
+        $service = app(UIEditorService::class);
+        $original = Dashboard::factory()->create(['user_id' => $this->user->id]);
+        DashboardWidget::factory()->count(3)->create(['dashboard_id' => $original->id]);
+
+        $duplicate = $service->duplicateDashboard($original, $this->user, 'Duplicated Dashboard');
+
+        expect($duplicate->name)->toBe('Duplicated Dashboard');
+        expect($duplicate->widgets)->toHaveCount(3);
+        expect($duplicate->id)->not->toBe($original->id);
+    });
+
+    it('sets a dashboard as default', function () {
+        $service = app(UIEditorService::class);
+        $dashboard1 = Dashboard::factory()->create([
+            'user_id' => $this->user->id,
+            'is_default' => true,
+        ]);
+        $dashboard2 = Dashboard::factory()->create([
+            'user_id' => $this->user->id,
+            'is_default' => false,
+        ]);
+
+        $service->setDefaultDashboard($this->user, $dashboard2);
+
+        $dashboard1->refresh();
+        $dashboard2->refresh();
+
+        expect($dashboard1->is_default)->toBeFalse();
+        expect($dashboard2->is_default)->toBeTrue();
+    });
+
+    it('creates a default dashboard for new users', function () {
+        $service = app(UIEditorService::class);
+
+        $dashboard = $service->createDefaultDashboard($this->user);
+
+        expect($dashboard->is_default)->toBeTrue();
+        expect($dashboard->widgets)->toHaveCount(6);
+    });
+});
+
+describe('Dashboard Model', function () {
+    it('generates a slug from the name', function () {
+        $dashboard = Dashboard::factory()->create([
+            'user_id' => $this->user->id,
+            'name' => 'My Test Dashboard',
+        ]);
+
+        expect($dashboard->slug)->toBe('my-test-dashboard');
+    });
+
+    it('returns the grid layout', function () {
+        $dashboard = Dashboard::factory()->create(['user_id' => $this->user->id]);
+        $widget = DashboardWidget::factory()->create([
+            'dashboard_id' => $dashboard->id,
+            'grid_x' => 0,
+            'grid_y' => 0,
+            'grid_w' => 4,
+            'grid_h' => 3,
+        ]);
+
+        $layout = $dashboard->getGridLayout();
+
+        expect($layout)->toHaveCount(1);
+        expect($layout[0])->toMatchArray([
+            'i' => $widget->id,
+            'x' => 0,
+            'y' => 0,
+            'w' => 4,
+            'h' => 3,
+        ]);
+    });
+});


### PR DESCRIPTION
Implement a comprehensive dashboard builder with drag-and-drop layout manager:

Backend:
- Add Dashboard, DashboardWidget, WidgetTemplate models
- Create UIEditorService for dashboard management
- Add UIEditorController with full CRUD operations
- Include Form Requests for validation
- Add DashboardPolicy for authorization
- Create database migration for dashboards tables
- Add widget template seeder with default widgets
- Add factories for testing

Frontend:
- Create dashboard builder pages (Index, Create, Edit, Show)
- Implement drag-and-drop widget placement
- Add widget toolbox with categorized templates
- Create 6 widget types: metrics, charts, tables, activity feed, quick actions, status overview
- Add widget configuration panel
- Create Pinia store for UI state management
- Add UI Editor to main navigation

Tests:
- Add comprehensive feature tests for dashboard CRUD
- Test widget management (add, update, remove)
- Test layout updates and authorization
- Test UIEditorService methods