### PR TITLE
Add Laravel equipment maintenance module (migrations, models, Filament resources & widget)

### DIFF
--- a/app/Filament/Resources/MaintenanceComplianceRecordResource.php
+++ b/app/Filament/Resources/MaintenanceComplianceRecordResource.php
@@ -1,0 +1,112 @@
+<?php
+
+// MaintenanceComplianceRecordResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceComplianceRecordResource\Pages;
+use App\Models\MaintenanceComplianceRecord;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceComplianceRecordResource extends Resource
+{
+    protected static ?string $model = MaintenanceComplianceRecord::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-shield-check';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 9;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Compliance Record')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    TextInput::make('standard')
+                        ->required()
+                        ->maxLength(255),
+                    Select::make('status')
+                        ->options([
+                            'compliant' => 'Compliant',
+                            'non_compliant' => 'Non-compliant',
+                            'pending' => 'Pending',
+                            'expired' => 'Expired',
+                        ])
+                        ->required(),
+                    DatePicker::make('last_audit_date'),
+                    DatePicker::make('next_audit_due'),
+                    Select::make('audited_by')
+                        ->relationship('auditedBy', 'name')
+                        ->searchable(),
+                    Textarea::make('evidence_location')
+                        ->columnSpanFull(),
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                ])
+                ->columns(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('standard')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('last_audit_date')
+                    ->date(),
+                Tables\Columns\TextColumn::make('next_audit_due')
+                    ->date(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'compliant' => 'Compliant',
+                        'non_compliant' => 'Non-compliant',
+                        'pending' => 'Pending',
+                        'expired' => 'Expired',
+                    ]),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('next_audit_due');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceComplianceRecords::route('/'),
+            'create' => Pages\CreateMaintenanceComplianceRecord::route('/create'),
+            'edit' => Pages\EditMaintenanceComplianceRecord::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/CreateMaintenanceComplianceRecord.php
+++ b/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/CreateMaintenanceComplianceRecord.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceComplianceRecord.php
+
+namespace App\Filament\Resources\MaintenanceComplianceRecordResource\Pages;
+
+use App\Filament\Resources\MaintenanceComplianceRecordResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceComplianceRecord extends CreateRecord
+{
+    protected static string $resource = MaintenanceComplianceRecordResource::class;
+}

--- a/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/EditMaintenanceComplianceRecord.php
+++ b/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/EditMaintenanceComplianceRecord.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceComplianceRecord.php
+
+namespace App\Filament\Resources\MaintenanceComplianceRecordResource\Pages;
+
+use App\Filament\Resources\MaintenanceComplianceRecordResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceComplianceRecord extends EditRecord
+{
+    protected static string $resource = MaintenanceComplianceRecordResource::class;
+}

--- a/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/ListMaintenanceComplianceRecords.php
+++ b/app/Filament/Resources/MaintenanceComplianceRecordResource/Pages/ListMaintenanceComplianceRecords.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceComplianceRecords.php
+
+namespace App\Filament\Resources\MaintenanceComplianceRecordResource\Pages;
+
+use App\Filament\Resources\MaintenanceComplianceRecordResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceComplianceRecords extends ListRecords
+{
+    protected static string $resource = MaintenanceComplianceRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceEquipmentAssetResource.php
+++ b/app/Filament/Resources/MaintenanceEquipmentAssetResource.php
@@ -1,0 +1,184 @@
+<?php
+
+// MaintenanceEquipmentAssetResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceEquipmentAssetResource\Pages;
+use App\Models\MaintenanceEquipmentAsset;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceEquipmentAssetResource extends Resource
+{
+    protected static ?string $model = MaintenanceEquipmentAsset::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-wrench-screwdriver';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Asset Overview')
+                ->schema([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255),
+                    Select::make('category_id')
+                        ->relationship('category', 'name')
+                        ->searchable()
+                        ->required(),
+                    TextInput::make('asset_tag')
+                        ->maxLength(100)
+                        ->unique(ignoreRecord: true),
+                    TextInput::make('serial_number')
+                        ->maxLength(100),
+                    Select::make('status')
+                        ->options([
+                            'active' => 'Active',
+                            'inactive' => 'Inactive',
+                            'in_repair' => 'In Repair',
+                            'out_of_service' => 'Out of Service',
+                            'decommissioned' => 'Decommissioned',
+                            'on_hire' => 'On Hire',
+                        ])
+                        ->required(),
+                    Select::make('criticality')
+                        ->options([
+                            'low' => 'Low',
+                            'medium' => 'Medium',
+                            'high' => 'High',
+                            'critical' => 'Critical',
+                        ])
+                        ->required(),
+                    Select::make('usage_unit')
+                        ->options([
+                            'hours' => 'Hours',
+                            'kilometres' => 'Kilometres',
+                            'cycles' => 'Cycles',
+                            'loads' => 'Loads',
+                        ])
+                        ->required(),
+                    TextInput::make('current_usage')
+                        ->numeric()
+                        ->step(0.01)
+                        ->required(),
+                    TextInput::make('next_service_due_usage')
+                        ->numeric()
+                        ->step(0.01),
+                    DatePicker::make('next_service_due_date'),
+                ])->columns(3),
+
+            Section::make('Ownership & Location')
+                ->schema([
+                    TextInput::make('location')
+                        ->maxLength(255),
+                    TextInput::make('department')
+                        ->maxLength(255),
+                    Select::make('responsible_user_id')
+                        ->relationship('responsibleUser', 'name')
+                        ->searchable(),
+                ])->columns(3),
+
+            Section::make('Asset Details')
+                ->schema([
+                    TextInput::make('manufacturer')
+                        ->maxLength(100),
+                    TextInput::make('model')
+                        ->maxLength(100),
+                    TextInput::make('year')
+                        ->numeric()
+                        ->minValue(1900)
+                        ->maxValue((int) date('Y') + 1),
+                    DatePicker::make('purchase_date'),
+                    DatePicker::make('in_service_date'),
+                    DatePicker::make('warranty_expiry'),
+                    DatePicker::make('last_inspection_date'),
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                ])->columns(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('category.name')
+                    ->label('Category')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('asset_tag')
+                    ->label('Asset Tag')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('criticality')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('current_usage')
+                    ->label('Usage')
+                    ->formatStateUsing(fn (MaintenanceEquipmentAsset $record): string =>
+                        $record->current_usage.' '.$record->usage_unit),
+                Tables\Columns\TextColumn::make('next_service_due_date')
+                    ->date()
+                    ->label('Next Service'),
+                Tables\Columns\TextColumn::make('location')
+                    ->searchable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'active' => 'Active',
+                        'inactive' => 'Inactive',
+                        'in_repair' => 'In Repair',
+                        'out_of_service' => 'Out of Service',
+                        'decommissioned' => 'Decommissioned',
+                        'on_hire' => 'On Hire',
+                    ]),
+                Tables\Filters\SelectFilter::make('criticality')
+                    ->options([
+                        'low' => 'Low',
+                        'medium' => 'Medium',
+                        'high' => 'High',
+                        'critical' => 'Critical',
+                    ]),
+            ])
+            ->actions([
+                Actions\ViewAction::make(),
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceEquipmentAssets::route('/'),
+            'create' => Pages\CreateMaintenanceEquipmentAsset::route('/create'),
+            'edit' => Pages\EditMaintenanceEquipmentAsset::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/CreateMaintenanceEquipmentAsset.php
+++ b/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/CreateMaintenanceEquipmentAsset.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceEquipmentAsset.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentAssetResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentAssetResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceEquipmentAsset extends CreateRecord
+{
+    protected static string $resource = MaintenanceEquipmentAssetResource::class;
+}

--- a/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/EditMaintenanceEquipmentAsset.php
+++ b/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/EditMaintenanceEquipmentAsset.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceEquipmentAsset.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentAssetResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentAssetResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceEquipmentAsset extends EditRecord
+{
+    protected static string $resource = MaintenanceEquipmentAssetResource::class;
+}

--- a/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/ListMaintenanceEquipmentAssets.php
+++ b/app/Filament/Resources/MaintenanceEquipmentAssetResource/Pages/ListMaintenanceEquipmentAssets.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceEquipmentAssets.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentAssetResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentAssetResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceEquipmentAssets extends ListRecords
+{
+    protected static string $resource = MaintenanceEquipmentAssetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceEquipmentCategoryResource.php
+++ b/app/Filament/Resources/MaintenanceEquipmentCategoryResource.php
@@ -1,0 +1,123 @@
+<?php
+
+// MaintenanceEquipmentCategoryResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceEquipmentCategoryResource\Pages;
+use App\Models\MaintenanceEquipmentCategory;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceEquipmentCategoryResource extends Resource
+{
+    protected static ?string $model = MaintenanceEquipmentCategory::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Category Details')
+                ->schema([
+                    TextInput::make('code')
+                        ->required()
+                        ->maxLength(30)
+                        ->unique(ignoreRecord: true),
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255),
+                    Select::make('default_criticality')
+                        ->options([
+                            'low' => 'Low',
+                            'medium' => 'Medium',
+                            'high' => 'High',
+                            'critical' => 'Critical',
+                        ])
+                        ->required(),
+                    Select::make('default_usage_unit')
+                        ->options([
+                            'hours' => 'Hours',
+                            'kilometres' => 'Kilometres',
+                            'cycles' => 'Cycles',
+                            'loads' => 'Loads',
+                        ])
+                        ->required(),
+                    TextInput::make('default_interval_value')
+                        ->numeric()
+                        ->minValue(1)
+                        ->label('Default Interval Value'),
+                    Select::make('default_interval_unit')
+                        ->options([
+                            'days' => 'Days',
+                            'hours' => 'Hours',
+                            'kilometres' => 'Kilometres',
+                            'cycles' => 'Cycles',
+                            'loads' => 'Loads',
+                        ])
+                        ->label('Default Interval Unit'),
+                    Textarea::make('description')
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('code')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('default_criticality')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('default_usage_unit')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('default_interval_value')
+                    ->label('Interval')
+                    ->formatStateUsing(fn (MaintenanceEquipmentCategory $record): string => $record->default_interval_value
+                        ? $record->default_interval_value.' '.$record->default_interval_unit
+                        : '—'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceEquipmentCategories::route('/'),
+            'create' => Pages\CreateMaintenanceEquipmentCategory::route('/create'),
+            'edit' => Pages\EditMaintenanceEquipmentCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/CreateMaintenanceEquipmentCategory.php
+++ b/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/CreateMaintenanceEquipmentCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceEquipmentCategory.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentCategoryResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentCategoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceEquipmentCategory extends CreateRecord
+{
+    protected static string $resource = MaintenanceEquipmentCategoryResource::class;
+}

--- a/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/EditMaintenanceEquipmentCategory.php
+++ b/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/EditMaintenanceEquipmentCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceEquipmentCategory.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentCategoryResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentCategoryResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceEquipmentCategory extends EditRecord
+{
+    protected static string $resource = MaintenanceEquipmentCategoryResource::class;
+}

--- a/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/ListMaintenanceEquipmentCategories.php
+++ b/app/Filament/Resources/MaintenanceEquipmentCategoryResource/Pages/ListMaintenanceEquipmentCategories.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceEquipmentCategories.php
+
+namespace App\Filament\Resources\MaintenanceEquipmentCategoryResource\Pages;
+
+use App\Filament\Resources\MaintenanceEquipmentCategoryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceEquipmentCategories extends ListRecords
+{
+    protected static string $resource = MaintenanceEquipmentCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceFaultReportResource.php
+++ b/app/Filament/Resources/MaintenanceFaultReportResource.php
@@ -1,0 +1,128 @@
+<?php
+
+// MaintenanceFaultReportResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceFaultReportResource\Pages;
+use App\Models\MaintenanceFaultReport;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceFaultReportResource extends Resource
+{
+    protected static ?string $model = MaintenanceFaultReport::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-exclamation-triangle';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 6;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Fault Report')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    Select::make('reported_by')
+                        ->relationship('reportedBy', 'name')
+                        ->searchable(),
+                    DateTimePicker::make('reported_at')
+                        ->required(),
+                    Select::make('severity')
+                        ->options([
+                            'low' => 'Low',
+                            'medium' => 'Medium',
+                            'high' => 'High',
+                            'critical' => 'Critical',
+                        ])
+                        ->required(),
+                    Select::make('status')
+                        ->options([
+                            'open' => 'Open',
+                            'in_progress' => 'In Progress',
+                            'resolved' => 'Resolved',
+                            'closed' => 'Closed',
+                        ])
+                        ->required(),
+                    Textarea::make('description')
+                        ->required()
+                        ->columnSpanFull(),
+                    Textarea::make('immediate_action')
+                        ->columnSpanFull(),
+                    Textarea::make('resolution_notes')
+                        ->columnSpanFull(),
+                    DateTimePicker::make('resolved_at'),
+                ])
+                ->columns(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('reported_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('severity')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('reportedBy.name')
+                    ->label('Reported By'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('severity')
+                    ->options([
+                        'low' => 'Low',
+                        'medium' => 'Medium',
+                        'high' => 'High',
+                        'critical' => 'Critical',
+                    ]),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'open' => 'Open',
+                        'in_progress' => 'In Progress',
+                        'resolved' => 'Resolved',
+                        'closed' => 'Closed',
+                    ]),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('reported_at', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceFaultReports::route('/'),
+            'create' => Pages\CreateMaintenanceFaultReport::route('/create'),
+            'edit' => Pages\EditMaintenanceFaultReport::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceFaultReportResource/Pages/CreateMaintenanceFaultReport.php
+++ b/app/Filament/Resources/MaintenanceFaultReportResource/Pages/CreateMaintenanceFaultReport.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceFaultReport.php
+
+namespace App\Filament\Resources\MaintenanceFaultReportResource\Pages;
+
+use App\Filament\Resources\MaintenanceFaultReportResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceFaultReport extends CreateRecord
+{
+    protected static string $resource = MaintenanceFaultReportResource::class;
+}

--- a/app/Filament/Resources/MaintenanceFaultReportResource/Pages/EditMaintenanceFaultReport.php
+++ b/app/Filament/Resources/MaintenanceFaultReportResource/Pages/EditMaintenanceFaultReport.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceFaultReport.php
+
+namespace App\Filament\Resources\MaintenanceFaultReportResource\Pages;
+
+use App\Filament\Resources\MaintenanceFaultReportResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceFaultReport extends EditRecord
+{
+    protected static string $resource = MaintenanceFaultReportResource::class;
+}

--- a/app/Filament/Resources/MaintenanceFaultReportResource/Pages/ListMaintenanceFaultReports.php
+++ b/app/Filament/Resources/MaintenanceFaultReportResource/Pages/ListMaintenanceFaultReports.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceFaultReports.php
+
+namespace App\Filament\Resources\MaintenanceFaultReportResource\Pages;
+
+use App\Filament\Resources\MaintenanceFaultReportResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceFaultReports extends ListRecords
+{
+    protected static string $resource = MaintenanceFaultReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceInspectionResource.php
+++ b/app/Filament/Resources/MaintenanceInspectionResource.php
@@ -1,0 +1,112 @@
+<?php
+
+// MaintenanceInspectionResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceInspectionResource\Pages;
+use App\Models\MaintenanceInspection;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceInspectionResource extends Resource
+{
+    protected static ?string $model = MaintenanceInspection::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-clipboard-document';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 5;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Inspection Details')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    Select::make('inspector_id')
+                        ->relationship('inspector', 'name')
+                        ->searchable(),
+                    DatePicker::make('inspection_date')
+                        ->required(),
+                    Select::make('condition_rating')
+                        ->options([
+                            'excellent' => 'Excellent',
+                            'good' => 'Good',
+                            'fair' => 'Fair',
+                            'poor' => 'Poor',
+                            'critical' => 'Critical',
+                        ])
+                        ->required(),
+                    Select::make('compliance_status')
+                        ->options([
+                            'compliant' => 'Compliant',
+                            'non_compliant' => 'Non-compliant',
+                            'pending' => 'Pending',
+                        ])
+                        ->required(),
+                    DatePicker::make('next_due_date'),
+                    Toggle::make('follow_up_required')
+                        ->label('Follow-up Required'),
+                    Textarea::make('findings')
+                        ->columnSpanFull(),
+                ])
+                ->columns(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('inspection_date')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('condition_rating')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('compliance_status')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('next_due_date')
+                    ->date(),
+                Tables\Columns\IconColumn::make('follow_up_required')
+                    ->boolean(),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('inspection_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceInspections::route('/'),
+            'create' => Pages\CreateMaintenanceInspection::route('/create'),
+            'edit' => Pages\EditMaintenanceInspection::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceInspectionResource/Pages/CreateMaintenanceInspection.php
+++ b/app/Filament/Resources/MaintenanceInspectionResource/Pages/CreateMaintenanceInspection.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceInspection.php
+
+namespace App\Filament\Resources\MaintenanceInspectionResource\Pages;
+
+use App\Filament\Resources\MaintenanceInspectionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceInspection extends CreateRecord
+{
+    protected static string $resource = MaintenanceInspectionResource::class;
+}

--- a/app/Filament/Resources/MaintenanceInspectionResource/Pages/EditMaintenanceInspection.php
+++ b/app/Filament/Resources/MaintenanceInspectionResource/Pages/EditMaintenanceInspection.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceInspection.php
+
+namespace App\Filament\Resources\MaintenanceInspectionResource\Pages;
+
+use App\Filament\Resources\MaintenanceInspectionResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceInspection extends EditRecord
+{
+    protected static string $resource = MaintenanceInspectionResource::class;
+}

--- a/app/Filament/Resources/MaintenanceInspectionResource/Pages/ListMaintenanceInspections.php
+++ b/app/Filament/Resources/MaintenanceInspectionResource/Pages/ListMaintenanceInspections.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceInspections.php
+
+namespace App\Filament\Resources\MaintenanceInspectionResource\Pages;
+
+use App\Filament\Resources\MaintenanceInspectionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceInspections extends ListRecords
+{
+    protected static string $resource = MaintenanceInspectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenancePartResource.php
+++ b/app/Filament/Resources/MaintenancePartResource.php
@@ -1,0 +1,131 @@
+<?php
+
+// MaintenancePartResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenancePartResource\Pages;
+use App\Models\MaintenancePart;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenancePartResource extends Resource
+{
+    protected static ?string $model = MaintenancePart::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-cog-8-tooth';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 8;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Part Details')
+                ->schema([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255),
+                    TextInput::make('part_number')
+                        ->maxLength(100),
+                    TextInput::make('category')
+                        ->maxLength(100),
+                    Select::make('vendor_id')
+                        ->relationship('vendor', 'name')
+                        ->searchable(),
+                    TextInput::make('unit_cost')
+                        ->numeric()
+                        ->step(0.01)
+                        ->required(),
+                    Toggle::make('is_active')
+                        ->label('Active')
+                        ->default(true),
+                ])
+                ->columns(3),
+
+            Section::make('Inventory')
+                ->schema([
+                    TextInput::make('quantity_on_hand')
+                        ->numeric()
+                        ->minValue(0)
+                        ->required(),
+                    TextInput::make('reorder_point')
+                        ->numeric()
+                        ->minValue(0),
+                    TextInput::make('reorder_qty')
+                        ->numeric()
+                        ->minValue(0),
+                    TextInput::make('lead_time_days')
+                        ->numeric()
+                        ->minValue(0),
+                    TextInput::make('inventory_location')
+                        ->maxLength(255),
+                    DatePicker::make('last_stocktake_at'),
+                ])
+                ->columns(3),
+
+            Section::make('Notes')
+                ->schema([
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('part_number')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('category')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('quantity_on_hand')
+                    ->label('On Hand')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('reorder_point')
+                    ->label('Reorder')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->filters([
+                Tables\Filters\TernaryFilter::make('is_active'),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceParts::route('/'),
+            'create' => Pages\CreateMaintenancePart::route('/create'),
+            'edit' => Pages\EditMaintenancePart::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenancePartResource/Pages/CreateMaintenancePart.php
+++ b/app/Filament/Resources/MaintenancePartResource/Pages/CreateMaintenancePart.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenancePart.php
+
+namespace App\Filament\Resources\MaintenancePartResource\Pages;
+
+use App\Filament\Resources\MaintenancePartResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenancePart extends CreateRecord
+{
+    protected static string $resource = MaintenancePartResource::class;
+}

--- a/app/Filament/Resources/MaintenancePartResource/Pages/EditMaintenancePart.php
+++ b/app/Filament/Resources/MaintenancePartResource/Pages/EditMaintenancePart.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenancePart.php
+
+namespace App\Filament\Resources\MaintenancePartResource\Pages;
+
+use App\Filament\Resources\MaintenancePartResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenancePart extends EditRecord
+{
+    protected static string $resource = MaintenancePartResource::class;
+}

--- a/app/Filament/Resources/MaintenancePartResource/Pages/ListMaintenanceParts.php
+++ b/app/Filament/Resources/MaintenancePartResource/Pages/ListMaintenanceParts.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceParts.php
+
+namespace App\Filament\Resources\MaintenancePartResource\Pages;
+
+use App\Filament\Resources\MaintenancePartResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceParts extends ListRecords
+{
+    protected static string $resource = MaintenancePartResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceProgramResource.php
+++ b/app/Filament/Resources/MaintenanceProgramResource.php
@@ -1,0 +1,162 @@
+<?php
+
+// MaintenanceProgramResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceProgramResource\Pages;
+use App\Models\MaintenanceProgram;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceProgramResource extends Resource
+{
+    protected static ?string $model = MaintenanceProgram::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-clipboard-document-check';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 3;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Program Details')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    TextInput::make('title')
+                        ->required()
+                        ->maxLength(255),
+                    TextInput::make('interval_value')
+                        ->numeric()
+                        ->minValue(1)
+                        ->required(),
+                    Select::make('interval_unit')
+                        ->options([
+                            'days' => 'Days',
+                            'hours' => 'Hours',
+                            'kilometres' => 'Kilometres',
+                            'cycles' => 'Cycles',
+                            'loads' => 'Loads',
+                        ])
+                        ->required(),
+                    Select::make('priority')
+                        ->options([
+                            'low' => 'Low',
+                            'medium' => 'Medium',
+                            'high' => 'High',
+                            'urgent' => 'Urgent',
+                        ])
+                        ->required(),
+                    TextInput::make('estimated_hours')
+                        ->numeric()
+                        ->step(0.25),
+                    Toggle::make('is_active')
+                        ->label('Active')
+                        ->default(true),
+                ])
+                ->columns(3),
+
+            Section::make('Standards & References')
+                ->schema([
+                    TextInput::make('procedure_reference')
+                        ->maxLength(255)
+                        ->placeholder('Manual section, SOP, or checklist reference'),
+                    Textarea::make('safety_standards')
+                        ->placeholder('e.g. LOLER, PUWER, ISO 9001')
+                        ->columnSpanFull(),
+                    Textarea::make('checklist')
+                        ->columnSpanFull(),
+                    Textarea::make('required_parts')
+                        ->columnSpanFull(),
+                ]),
+
+            Section::make('Program Tasks')
+                ->schema([
+                    Repeater::make('programTasks')
+                        ->relationship()
+                        ->schema([
+                            TextInput::make('sequence')
+                                ->numeric()
+                                ->minValue(1)
+                                ->default(1)
+                                ->required(),
+                            TextInput::make('description')
+                                ->required()
+                                ->maxLength(255)
+                                ->columnSpan(2),
+                            Toggle::make('is_mandatory')
+                                ->default(true),
+                            TextInput::make('expected_minutes')
+                                ->numeric()
+                                ->minValue(1)
+                                ->label('Expected Minutes'),
+                            Textarea::make('reference_notes')
+                                ->columnSpanFull(),
+                        ])
+                        ->columns(4)
+                        ->defaultItems(0)
+                        ->addActionLabel('Add Task')
+                        ->reorderable(),
+                ])
+                ->collapsible(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('interval_value')
+                    ->label('Interval')
+                    ->formatStateUsing(fn (MaintenanceProgram $record): string =>
+                        $record->interval_value.' '.$record->interval_unit),
+                Tables\Columns\TextColumn::make('priority')
+                    ->badge(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('title');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenancePrograms::route('/'),
+            'create' => Pages\CreateMaintenanceProgram::route('/create'),
+            'edit' => Pages\EditMaintenanceProgram::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceProgramResource/Pages/CreateMaintenanceProgram.php
+++ b/app/Filament/Resources/MaintenanceProgramResource/Pages/CreateMaintenanceProgram.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceProgram.php
+
+namespace App\Filament\Resources\MaintenanceProgramResource\Pages;
+
+use App\Filament\Resources\MaintenanceProgramResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceProgram extends CreateRecord
+{
+    protected static string $resource = MaintenanceProgramResource::class;
+}

--- a/app/Filament/Resources/MaintenanceProgramResource/Pages/EditMaintenanceProgram.php
+++ b/app/Filament/Resources/MaintenanceProgramResource/Pages/EditMaintenanceProgram.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceProgram.php
+
+namespace App\Filament\Resources\MaintenanceProgramResource\Pages;
+
+use App\Filament\Resources\MaintenanceProgramResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceProgram extends EditRecord
+{
+    protected static string $resource = MaintenanceProgramResource::class;
+}

--- a/app/Filament/Resources/MaintenanceProgramResource/Pages/ListMaintenancePrograms.php
+++ b/app/Filament/Resources/MaintenanceProgramResource/Pages/ListMaintenancePrograms.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenancePrograms.php
+
+namespace App\Filament\Resources\MaintenanceProgramResource\Pages;
+
+use App\Filament\Resources\MaintenanceProgramResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenancePrograms extends ListRecords
+{
+    protected static string $resource = MaintenanceProgramResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceUsageLogResource.php
+++ b/app/Filament/Resources/MaintenanceUsageLogResource.php
@@ -1,0 +1,97 @@
+<?php
+
+// MaintenanceUsageLogResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceUsageLogResource\Pages;
+use App\Models\MaintenanceUsageLog;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceUsageLogResource extends Resource
+{
+    protected static ?string $model = MaintenanceUsageLog::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-clock';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 10;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Usage Log')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    DatePicker::make('usage_date')
+                        ->required(),
+                    TextInput::make('usage_amount')
+                        ->numeric()
+                        ->step(0.01)
+                        ->required(),
+                    TextInput::make('meter_reading')
+                        ->numeric()
+                        ->step(0.01),
+                    Select::make('logged_by')
+                        ->relationship('loggedBy', 'name')
+                        ->searchable(),
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                ])
+                ->columns(3),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('usage_date')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('usage_amount')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('meter_reading'),
+                Tables\Columns\TextColumn::make('loggedBy.name')
+                    ->label('Logged By'),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('usage_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceUsageLogs::route('/'),
+            'create' => Pages\CreateMaintenanceUsageLog::route('/create'),
+            'edit' => Pages\EditMaintenanceUsageLog::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceUsageLogResource/Pages/CreateMaintenanceUsageLog.php
+++ b/app/Filament/Resources/MaintenanceUsageLogResource/Pages/CreateMaintenanceUsageLog.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceUsageLog.php
+
+namespace App\Filament\Resources\MaintenanceUsageLogResource\Pages;
+
+use App\Filament\Resources\MaintenanceUsageLogResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceUsageLog extends CreateRecord
+{
+    protected static string $resource = MaintenanceUsageLogResource::class;
+}

--- a/app/Filament/Resources/MaintenanceUsageLogResource/Pages/EditMaintenanceUsageLog.php
+++ b/app/Filament/Resources/MaintenanceUsageLogResource/Pages/EditMaintenanceUsageLog.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceUsageLog.php
+
+namespace App\Filament\Resources\MaintenanceUsageLogResource\Pages;
+
+use App\Filament\Resources\MaintenanceUsageLogResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceUsageLog extends EditRecord
+{
+    protected static string $resource = MaintenanceUsageLogResource::class;
+}

--- a/app/Filament/Resources/MaintenanceUsageLogResource/Pages/ListMaintenanceUsageLogs.php
+++ b/app/Filament/Resources/MaintenanceUsageLogResource/Pages/ListMaintenanceUsageLogs.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceUsageLogs.php
+
+namespace App\Filament\Resources\MaintenanceUsageLogResource\Pages;
+
+use App\Filament\Resources\MaintenanceUsageLogResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceUsageLogs extends ListRecords
+{
+    protected static string $resource = MaintenanceUsageLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceVendorResource.php
+++ b/app/Filament/Resources/MaintenanceVendorResource.php
@@ -1,0 +1,107 @@
+<?php
+
+// MaintenanceVendorResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceVendorResource\Pages;
+use App\Models\MaintenanceVendor;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceVendorResource extends Resource
+{
+    protected static ?string $model = MaintenanceVendor::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-building-storefront';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 7;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Vendor Details')
+                ->schema([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255),
+                    TextInput::make('service_type')
+                        ->maxLength(100)
+                        ->placeholder('Hydraulics, Welding, Inspections, etc.'),
+                    TextInput::make('contact_name')
+                        ->maxLength(255),
+                    TextInput::make('email')
+                        ->email()
+                        ->maxLength(255),
+                    TextInput::make('phone')
+                        ->tel()
+                        ->maxLength(50),
+                    TextInput::make('website')
+                        ->maxLength(255),
+                    TextInput::make('emergency_contact')
+                        ->maxLength(255),
+                    Textarea::make('address')
+                        ->columnSpanFull(),
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                    Toggle::make('is_active')
+                        ->label('Active')
+                        ->default(true),
+                ])
+                ->columns(2),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('service_type')
+                    ->label('Service Type')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('contact_name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('phone')
+                    ->searchable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->filters([
+                Tables\Filters\TernaryFilter::make('is_active'),
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceVendors::route('/'),
+            'create' => Pages\CreateMaintenanceVendor::route('/create'),
+            'edit' => Pages\EditMaintenanceVendor::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceVendorResource/Pages/CreateMaintenanceVendor.php
+++ b/app/Filament/Resources/MaintenanceVendorResource/Pages/CreateMaintenanceVendor.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceVendor.php
+
+namespace App\Filament\Resources\MaintenanceVendorResource\Pages;
+
+use App\Filament\Resources\MaintenanceVendorResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceVendor extends CreateRecord
+{
+    protected static string $resource = MaintenanceVendorResource::class;
+}

--- a/app/Filament/Resources/MaintenanceVendorResource/Pages/EditMaintenanceVendor.php
+++ b/app/Filament/Resources/MaintenanceVendorResource/Pages/EditMaintenanceVendor.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceVendor.php
+
+namespace App\Filament\Resources\MaintenanceVendorResource\Pages;
+
+use App\Filament\Resources\MaintenanceVendorResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceVendor extends EditRecord
+{
+    protected static string $resource = MaintenanceVendorResource::class;
+}

--- a/app/Filament/Resources/MaintenanceVendorResource/Pages/ListMaintenanceVendors.php
+++ b/app/Filament/Resources/MaintenanceVendorResource/Pages/ListMaintenanceVendors.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceVendors.php
+
+namespace App\Filament\Resources\MaintenanceVendorResource\Pages;
+
+use App\Filament\Resources\MaintenanceVendorResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceVendors extends ListRecords
+{
+    protected static string $resource = MaintenanceVendorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceWorkOrderResource.php
+++ b/app/Filament/Resources/MaintenanceWorkOrderResource.php
@@ -1,0 +1,225 @@
+<?php
+
+// MaintenanceWorkOrderResource.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\MaintenanceWorkOrderResource\Pages;
+use App\Models\MaintenanceWorkOrder;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class MaintenanceWorkOrderResource extends Resource
+{
+    protected static ?string $model = MaintenanceWorkOrder::class;
+
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static UnitEnum|string|null $navigationGroup = 'Maintenance';
+
+    protected static ?int $navigationSort = 4;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Work Order Summary')
+                ->schema([
+                    Select::make('equipment_id')
+                        ->relationship('equipment', 'name')
+                        ->searchable()
+                        ->required(),
+                    Select::make('maintenance_program_id')
+                        ->relationship('maintenanceProgram', 'title')
+                        ->searchable(),
+                    Select::make('fault_report_id')
+                        ->relationship('faultReport', 'id')
+                        ->searchable()
+                        ->label('Fault Report'),
+                    TextInput::make('title')
+                        ->required()
+                        ->maxLength(255),
+                    Textarea::make('description')
+                        ->columnSpanFull(),
+                    Select::make('status')
+                        ->options([
+                            'open' => 'Open',
+                            'scheduled' => 'Scheduled',
+                            'in_progress' => 'In Progress',
+                            'blocked' => 'Blocked',
+                            'completed' => 'Completed',
+                            'cancelled' => 'Cancelled',
+                        ])
+                        ->required(),
+                    Select::make('priority')
+                        ->options([
+                            'low' => 'Low',
+                            'medium' => 'Medium',
+                            'high' => 'High',
+                            'urgent' => 'Urgent',
+                        ])
+                        ->required(),
+                ])
+                ->columns(3),
+
+            Section::make('Scheduling & Ownership')
+                ->schema([
+                    Select::make('requested_by')
+                        ->relationship('requestedBy', 'name')
+                        ->searchable(),
+                    Select::make('assigned_to')
+                        ->relationship('assignedTo', 'name')
+                        ->searchable(),
+                    DatePicker::make('scheduled_date'),
+                    DatePicker::make('due_date'),
+                    DateTimePicker::make('started_at'),
+                    DateTimePicker::make('completed_at'),
+                ])
+                ->columns(3),
+
+            Section::make('Operational Metrics')
+                ->schema([
+                    TextInput::make('labour_hours')
+                        ->numeric()
+                        ->step(0.25),
+                    TextInput::make('downtime_hours')
+                        ->numeric()
+                        ->step(0.25),
+                    TextInput::make('meter_reading')
+                        ->numeric()
+                        ->step(0.01),
+                    TextInput::make('location')
+                        ->maxLength(255),
+                    Textarea::make('completion_notes')
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+
+            Section::make('Tasks')
+                ->schema([
+                    Repeater::make('tasks')
+                        ->relationship()
+                        ->schema([
+                            TextInput::make('description')
+                                ->required()
+                                ->maxLength(255)
+                                ->columnSpan(2),
+                            Select::make('completed_by')
+                                ->relationship('completedBy', 'name')
+                                ->searchable(),
+                            DateTimePicker::make('completed_at'),
+                            Textarea::make('notes')
+                                ->columnSpanFull(),
+                        ])
+                        ->columns(3)
+                        ->defaultItems(0)
+                        ->addActionLabel('Add Task')
+                        ->reorderable(),
+                ])
+                ->collapsible(),
+
+            Section::make('Parts Usage')
+                ->schema([
+                    Repeater::make('partUsages')
+                        ->relationship()
+                        ->schema([
+                            Select::make('part_id')
+                                ->relationship('part', 'name')
+                                ->searchable()
+                                ->required()
+                                ->columnSpan(2),
+                            TextInput::make('quantity')
+                                ->numeric()
+                                ->minValue(1)
+                                ->required(),
+                            TextInput::make('unit_cost')
+                                ->numeric()
+                                ->step(0.01),
+                            TextInput::make('cost_total')
+                                ->numeric()
+                                ->step(0.01),
+                            DateTimePicker::make('used_at'),
+                            Textarea::make('notes')
+                                ->columnSpanFull(),
+                        ])
+                        ->columns(3)
+                        ->defaultItems(0)
+                        ->addActionLabel('Add Part Usage')
+                        ->reorderable(),
+                ])
+                ->collapsible(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('equipment.name')
+                    ->label('Equipment')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('priority')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('due_date')
+                    ->date(),
+                Tables\Columns\TextColumn::make('assignedTo.name')
+                    ->label('Assigned'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'open' => 'Open',
+                        'scheduled' => 'Scheduled',
+                        'in_progress' => 'In Progress',
+                        'blocked' => 'Blocked',
+                        'completed' => 'Completed',
+                        'cancelled' => 'Cancelled',
+                    ]),
+                Tables\Filters\SelectFilter::make('priority')
+                    ->options([
+                        'low' => 'Low',
+                        'medium' => 'Medium',
+                        'high' => 'High',
+                        'urgent' => 'Urgent',
+                    ]),
+            ])
+            ->actions([
+                Actions\ViewAction::make(),
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('due_date');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMaintenanceWorkOrders::route('/'),
+            'create' => Pages\CreateMaintenanceWorkOrder::route('/create'),
+            'edit' => Pages\EditMaintenanceWorkOrder::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/CreateMaintenanceWorkOrder.php
+++ b/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/CreateMaintenanceWorkOrder.php
@@ -1,0 +1,13 @@
+<?php
+
+// CreateMaintenanceWorkOrder.php
+
+namespace App\Filament\Resources\MaintenanceWorkOrderResource\Pages;
+
+use App\Filament\Resources\MaintenanceWorkOrderResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateMaintenanceWorkOrder extends CreateRecord
+{
+    protected static string $resource = MaintenanceWorkOrderResource::class;
+}

--- a/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/EditMaintenanceWorkOrder.php
+++ b/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/EditMaintenanceWorkOrder.php
@@ -1,0 +1,13 @@
+<?php
+
+// EditMaintenanceWorkOrder.php
+
+namespace App\Filament\Resources\MaintenanceWorkOrderResource\Pages;
+
+use App\Filament\Resources\MaintenanceWorkOrderResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditMaintenanceWorkOrder extends EditRecord
+{
+    protected static string $resource = MaintenanceWorkOrderResource::class;
+}

--- a/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/ListMaintenanceWorkOrders.php
+++ b/app/Filament/Resources/MaintenanceWorkOrderResource/Pages/ListMaintenanceWorkOrders.php
@@ -1,0 +1,21 @@
+<?php
+
+// ListMaintenanceWorkOrders.php
+
+namespace App\Filament\Resources\MaintenanceWorkOrderResource\Pages;
+
+use App\Filament\Resources\MaintenanceWorkOrderResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMaintenanceWorkOrders extends ListRecords
+{
+    protected static string $resource = MaintenanceWorkOrderResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Widgets/EquipmentMaintenanceOverview.php
+++ b/app/Filament/Widgets/EquipmentMaintenanceOverview.php
@@ -1,0 +1,72 @@
+<?php
+
+// EquipmentMaintenanceOverview.php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Models\MaintenanceComplianceRecord;
+use App\Models\MaintenanceEquipmentAsset;
+use App\Models\MaintenanceInspection;
+use App\Models\MaintenancePart;
+use App\Models\MaintenanceWorkOrder;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
+
+class EquipmentMaintenanceOverview extends StatsOverviewWidget
+{
+    protected static ?string $heading = 'Equipment Maintenance Snapshot';
+
+    protected function getStats(): array
+    {
+        $today = Carbon::today();
+
+        $openWorkOrders = MaintenanceWorkOrder::query()
+            ->whereIn('status', ['open', 'scheduled', 'in_progress', 'blocked'])
+            ->count();
+
+        $overdueInspections = MaintenanceInspection::query()
+            ->whereNotNull('next_due_date')
+            ->whereDate('next_due_date', '<', $today)
+            ->count();
+
+        $lowStockParts = MaintenancePart::query()
+            ->whereNotNull('reorder_point')
+            ->whereColumn('quantity_on_hand', '<=', 'reorder_point')
+            ->count();
+
+        $complianceOverdue = MaintenanceComplianceRecord::query()
+            ->whereNotNull('next_audit_due')
+            ->whereDate('next_audit_due', '<', $today)
+            ->count();
+
+        $activeAssets = MaintenanceEquipmentAsset::query()
+            ->where('status', 'active')
+            ->count();
+
+        return [
+            Stat::make('Active Assets', $activeAssets)
+                ->description('Operational equipment in service')
+                ->color('success'),
+            Stat::make('Open Work Orders', $openWorkOrders)
+                ->description('Awaiting completion or scheduling')
+                ->color('warning'),
+            Stat::make('Overdue Inspections', $overdueInspections)
+                ->description('Inspections past due')
+                ->color('danger'),
+            Stat::make('Low Stock Parts', $lowStockParts)
+                ->description('Below reorder point')
+                ->color('warning'),
+            Stat::make('Compliance Overdue', $complianceOverdue)
+                ->description('Audits past due')
+                ->color('danger'),
+        ];
+    }
+
+    public static function getSort(): int
+    {
+        return 4;
+    }
+}

--- a/app/Models/MaintenanceComplianceRecord.php
+++ b/app/Models/MaintenanceComplianceRecord.php
@@ -1,0 +1,52 @@
+<?php
+
+// MaintenanceComplianceRecord.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property string $standard
+ * @property string $status
+ * @property string|null $last_audit_date
+ * @property string|null $next_audit_due
+ * @property string|null $evidence_location
+ * @property string|null $notes
+ * @property int|null $audited_by
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read User|null $auditedBy
+ */
+class MaintenanceComplianceRecord extends Model
+{
+    protected $fillable = [
+        'equipment_id',
+        'standard',
+        'status',
+        'last_audit_date',
+        'next_audit_due',
+        'evidence_location',
+        'notes',
+        'audited_by',
+    ];
+
+    protected $casts = [
+        'last_audit_date' => 'date',
+        'next_audit_due' => 'date',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function auditedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'audited_by');
+    }
+}

--- a/app/Models/MaintenanceEquipmentAsset.php
+++ b/app/Models/MaintenanceEquipmentAsset.php
@@ -1,0 +1,124 @@
+<?php
+
+// MaintenanceEquipmentAsset.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property int $category_id
+ * @property string $name
+ * @property string|null $asset_tag
+ * @property string|null $serial_number
+ * @property string|null $manufacturer
+ * @property string|null $model
+ * @property int|null $year
+ * @property string|null $purchase_date
+ * @property string|null $in_service_date
+ * @property string $status
+ * @property string|null $location
+ * @property string|null $department
+ * @property string $criticality
+ * @property string $usage_unit
+ * @property float $current_usage
+ * @property float|null $next_service_due_usage
+ * @property string|null $next_service_due_date
+ * @property string|null $warranty_expiry
+ * @property string|null $last_inspection_date
+ * @property int|null $responsible_user_id
+ * @property string|null $notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read MaintenanceEquipmentCategory $category
+ * @property-read User|null $responsibleUser
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceUsageLog> $usageLogs
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceProgram> $maintenancePrograms
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceInspection> $inspections
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceFaultReport> $faultReports
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceWorkOrder> $workOrders
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceComplianceRecord> $complianceRecords
+ */
+class MaintenanceEquipmentAsset extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'category_id',
+        'name',
+        'asset_tag',
+        'serial_number',
+        'manufacturer',
+        'model',
+        'year',
+        'purchase_date',
+        'in_service_date',
+        'status',
+        'location',
+        'department',
+        'criticality',
+        'usage_unit',
+        'current_usage',
+        'next_service_due_usage',
+        'next_service_due_date',
+        'warranty_expiry',
+        'last_inspection_date',
+        'responsible_user_id',
+        'notes',
+    ];
+
+    protected $casts = [
+        'purchase_date' => 'date',
+        'in_service_date' => 'date',
+        'next_service_due_date' => 'date',
+        'warranty_expiry' => 'date',
+        'last_inspection_date' => 'date',
+        'current_usage' => 'decimal:2',
+        'next_service_due_usage' => 'decimal:2',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentCategory::class, 'category_id');
+    }
+
+    public function responsibleUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'responsible_user_id');
+    }
+
+    public function usageLogs(): HasMany
+    {
+        return $this->hasMany(MaintenanceUsageLog::class, 'equipment_id');
+    }
+
+    public function maintenancePrograms(): HasMany
+    {
+        return $this->hasMany(MaintenanceProgram::class, 'equipment_id');
+    }
+
+    public function inspections(): HasMany
+    {
+        return $this->hasMany(MaintenanceInspection::class, 'equipment_id');
+    }
+
+    public function faultReports(): HasMany
+    {
+        return $this->hasMany(MaintenanceFaultReport::class, 'equipment_id');
+    }
+
+    public function workOrders(): HasMany
+    {
+        return $this->hasMany(MaintenanceWorkOrder::class, 'equipment_id');
+    }
+
+    public function complianceRecords(): HasMany
+    {
+        return $this->hasMany(MaintenanceComplianceRecord::class, 'equipment_id');
+    }
+}

--- a/app/Models/MaintenanceEquipmentCategory.php
+++ b/app/Models/MaintenanceEquipmentCategory.php
@@ -1,0 +1,39 @@
+<?php
+
+// MaintenanceEquipmentCategory.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $code
+ * @property string $name
+ * @property string|null $description
+ * @property string $default_criticality
+ * @property string $default_usage_unit
+ * @property int|null $default_interval_value
+ * @property string|null $default_interval_unit
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceEquipmentAsset> $assets
+ */
+class MaintenanceEquipmentCategory extends Model
+{
+    protected $fillable = [
+        'code',
+        'name',
+        'description',
+        'default_criticality',
+        'default_usage_unit',
+        'default_interval_value',
+        'default_interval_unit',
+    ];
+
+    public function assets(): HasMany
+    {
+        return $this->hasMany(MaintenanceEquipmentAsset::class, 'category_id');
+    }
+}

--- a/app/Models/MaintenanceFaultReport.php
+++ b/app/Models/MaintenanceFaultReport.php
@@ -1,0 +1,61 @@
+<?php
+
+// MaintenanceFaultReport.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property int|null $reported_by
+ * @property string $reported_at
+ * @property string $severity
+ * @property string $description
+ * @property string|null $immediate_action
+ * @property string $status
+ * @property string|null $resolution_notes
+ * @property string|null $resolved_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read User|null $reportedBy
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceWorkOrder> $workOrders
+ */
+class MaintenanceFaultReport extends Model
+{
+    protected $fillable = [
+        'equipment_id',
+        'reported_by',
+        'reported_at',
+        'severity',
+        'description',
+        'immediate_action',
+        'status',
+        'resolution_notes',
+        'resolved_at',
+    ];
+
+    protected $casts = [
+        'reported_at' => 'datetime',
+        'resolved_at' => 'datetime',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function reportedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reported_by');
+    }
+
+    public function workOrders(): HasMany
+    {
+        return $this->hasMany(MaintenanceWorkOrder::class, 'fault_report_id');
+    }
+}

--- a/app/Models/MaintenanceInspection.php
+++ b/app/Models/MaintenanceInspection.php
@@ -1,0 +1,53 @@
+<?php
+
+// MaintenanceInspection.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property int|null $inspector_id
+ * @property string $inspection_date
+ * @property string $condition_rating
+ * @property string $compliance_status
+ * @property string|null $findings
+ * @property string|null $next_due_date
+ * @property bool $follow_up_required
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read User|null $inspector
+ */
+class MaintenanceInspection extends Model
+{
+    protected $fillable = [
+        'equipment_id',
+        'inspector_id',
+        'inspection_date',
+        'condition_rating',
+        'compliance_status',
+        'findings',
+        'next_due_date',
+        'follow_up_required',
+    ];
+
+    protected $casts = [
+        'inspection_date' => 'date',
+        'next_due_date' => 'date',
+        'follow_up_required' => 'boolean',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function inspector(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'inspector_id');
+    }
+}

--- a/app/Models/MaintenancePart.php
+++ b/app/Models/MaintenancePart.php
@@ -1,0 +1,65 @@
+<?php
+
+// MaintenancePart.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int|null $vendor_id
+ * @property string $name
+ * @property string|null $part_number
+ * @property string|null $category
+ * @property float $unit_cost
+ * @property int $quantity_on_hand
+ * @property int|null $reorder_point
+ * @property int|null $reorder_qty
+ * @property int|null $lead_time_days
+ * @property string|null $inventory_location
+ * @property string|null $last_stocktake_at
+ * @property string|null $notes
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceVendor|null $vendor
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenancePartUsage> $partUsages
+ */
+class MaintenancePart extends Model
+{
+    protected $fillable = [
+        'vendor_id',
+        'name',
+        'part_number',
+        'category',
+        'unit_cost',
+        'quantity_on_hand',
+        'reorder_point',
+        'reorder_qty',
+        'lead_time_days',
+        'inventory_location',
+        'last_stocktake_at',
+        'notes',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'unit_cost' => 'decimal:2',
+        'quantity_on_hand' => 'integer',
+        'last_stocktake_at' => 'date',
+        'is_active' => 'boolean',
+    ];
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceVendor::class, 'vendor_id');
+    }
+
+    public function partUsages(): HasMany
+    {
+        return $this->hasMany(MaintenancePartUsage::class, 'part_id');
+    }
+}

--- a/app/Models/MaintenancePartUsage.php
+++ b/app/Models/MaintenancePartUsage.php
@@ -1,0 +1,59 @@
+<?php
+
+// MaintenancePartUsage.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $work_order_id
+ * @property int $part_id
+ * @property int $quantity
+ * @property float $unit_cost
+ * @property float $cost_total
+ * @property string|null $used_at
+ * @property string|null $notes
+ * @property int|null $created_by
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceWorkOrder $workOrder
+ * @property-read MaintenancePart $part
+ * @property-read User|null $createdBy
+ */
+class MaintenancePartUsage extends Model
+{
+    protected $fillable = [
+        'work_order_id',
+        'part_id',
+        'quantity',
+        'unit_cost',
+        'cost_total',
+        'used_at',
+        'notes',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'unit_cost' => 'decimal:2',
+        'cost_total' => 'decimal:2',
+        'used_at' => 'datetime',
+    ];
+
+    public function workOrder(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceWorkOrder::class, 'work_order_id');
+    }
+
+    public function part(): BelongsTo
+    {
+        return $this->belongsTo(MaintenancePart::class, 'part_id');
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/MaintenanceProgram.php
+++ b/app/Models/MaintenanceProgram.php
@@ -1,0 +1,71 @@
+<?php
+
+// MaintenanceProgram.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property string $title
+ * @property int $interval_value
+ * @property string $interval_unit
+ * @property string|null $checklist
+ * @property string|null $required_parts
+ * @property string|null $safety_standards
+ * @property string|null $procedure_reference
+ * @property float|null $estimated_hours
+ * @property string $priority
+ * @property bool $is_active
+ * @property int|null $created_by
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read User|null $createdBy
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceProgramTask> $programTasks
+ */
+class MaintenanceProgram extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'equipment_id',
+        'title',
+        'interval_value',
+        'interval_unit',
+        'checklist',
+        'required_parts',
+        'safety_standards',
+        'procedure_reference',
+        'estimated_hours',
+        'priority',
+        'is_active',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'estimated_hours' => 'decimal:2',
+        'is_active' => 'boolean',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function programTasks(): HasMany
+    {
+        return $this->hasMany(MaintenanceProgramTask::class, 'program_id')->orderBy('sequence');
+    }
+}

--- a/app/Models/MaintenanceProgramTask.php
+++ b/app/Models/MaintenanceProgramTask.php
@@ -1,0 +1,41 @@
+<?php
+
+// MaintenanceProgramTask.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $program_id
+ * @property int $sequence
+ * @property string $description
+ * @property bool $is_mandatory
+ * @property int|null $expected_minutes
+ * @property string|null $reference_notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceProgram $program
+ */
+class MaintenanceProgramTask extends Model
+{
+    protected $fillable = [
+        'program_id',
+        'sequence',
+        'description',
+        'is_mandatory',
+        'expected_minutes',
+        'reference_notes',
+    ];
+
+    protected $casts = [
+        'is_mandatory' => 'boolean',
+    ];
+
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceProgram::class, 'program_id');
+    }
+}

--- a/app/Models/MaintenanceUsageLog.php
+++ b/app/Models/MaintenanceUsageLog.php
@@ -1,0 +1,49 @@
+<?php
+
+// MaintenanceUsageLog.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property string $usage_date
+ * @property float $usage_amount
+ * @property float|null $meter_reading
+ * @property int|null $logged_by
+ * @property string|null $notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read User|null $loggedBy
+ */
+class MaintenanceUsageLog extends Model
+{
+    protected $fillable = [
+        'equipment_id',
+        'usage_date',
+        'usage_amount',
+        'meter_reading',
+        'logged_by',
+        'notes',
+    ];
+
+    protected $casts = [
+        'usage_date' => 'date',
+        'usage_amount' => 'decimal:2',
+        'meter_reading' => 'decimal:2',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function loggedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'logged_by');
+    }
+}

--- a/app/Models/MaintenanceVendor.php
+++ b/app/Models/MaintenanceVendor.php
@@ -1,0 +1,49 @@
+<?php
+
+// MaintenanceVendor.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string|null $service_type
+ * @property string|null $contact_name
+ * @property string|null $email
+ * @property string|null $phone
+ * @property string|null $address
+ * @property string|null $website
+ * @property string|null $emergency_contact
+ * @property string|null $notes
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenancePart> $parts
+ */
+class MaintenanceVendor extends Model
+{
+    protected $fillable = [
+        'name',
+        'service_type',
+        'contact_name',
+        'email',
+        'phone',
+        'address',
+        'website',
+        'emergency_contact',
+        'notes',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function parts(): HasMany
+    {
+        return $this->hasMany(MaintenancePart::class, 'vendor_id');
+    }
+}

--- a/app/Models/MaintenanceWorkOrder.php
+++ b/app/Models/MaintenanceWorkOrder.php
@@ -1,0 +1,112 @@
+<?php
+
+// MaintenanceWorkOrder.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property int $equipment_id
+ * @property int|null $maintenance_program_id
+ * @property int|null $fault_report_id
+ * @property string $title
+ * @property string|null $description
+ * @property string $status
+ * @property string $priority
+ * @property int|null $requested_by
+ * @property int|null $assigned_to
+ * @property string|null $scheduled_date
+ * @property string|null $due_date
+ * @property string|null $started_at
+ * @property string|null $completed_at
+ * @property float|null $labour_hours
+ * @property float|null $downtime_hours
+ * @property string|null $location
+ * @property float|null $meter_reading
+ * @property string|null $completion_notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read MaintenanceEquipmentAsset $equipment
+ * @property-read MaintenanceProgram|null $maintenanceProgram
+ * @property-read MaintenanceFaultReport|null $faultReport
+ * @property-read User|null $requestedBy
+ * @property-read User|null $assignedTo
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenanceWorkOrderTask> $tasks
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, MaintenancePartUsage> $partUsages
+ */
+class MaintenanceWorkOrder extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'equipment_id',
+        'maintenance_program_id',
+        'fault_report_id',
+        'title',
+        'description',
+        'status',
+        'priority',
+        'requested_by',
+        'assigned_to',
+        'scheduled_date',
+        'due_date',
+        'started_at',
+        'completed_at',
+        'labour_hours',
+        'downtime_hours',
+        'location',
+        'meter_reading',
+        'completion_notes',
+    ];
+
+    protected $casts = [
+        'scheduled_date' => 'date',
+        'due_date' => 'date',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'labour_hours' => 'decimal:2',
+        'downtime_hours' => 'decimal:2',
+        'meter_reading' => 'decimal:2',
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceEquipmentAsset::class, 'equipment_id');
+    }
+
+    public function maintenanceProgram(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceProgram::class, 'maintenance_program_id');
+    }
+
+    public function faultReport(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceFaultReport::class, 'fault_report_id');
+    }
+
+    public function requestedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'requested_by');
+    }
+
+    public function assignedTo(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
+    }
+
+    public function tasks(): HasMany
+    {
+        return $this->hasMany(MaintenanceWorkOrderTask::class, 'work_order_id');
+    }
+
+    public function partUsages(): HasMany
+    {
+        return $this->hasMany(MaintenancePartUsage::class, 'work_order_id');
+    }
+}

--- a/app/Models/MaintenanceWorkOrderTask.php
+++ b/app/Models/MaintenanceWorkOrderTask.php
@@ -1,0 +1,48 @@
+<?php
+
+// MaintenanceWorkOrderTask.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $work_order_id
+ * @property string $description
+ * @property bool $is_completed
+ * @property string|null $completed_at
+ * @property int|null $completed_by
+ * @property string|null $notes
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read MaintenanceWorkOrder $workOrder
+ * @property-read User|null $completedBy
+ */
+class MaintenanceWorkOrderTask extends Model
+{
+    protected $fillable = [
+        'work_order_id',
+        'description',
+        'is_completed',
+        'completed_at',
+        'completed_by',
+        'notes',
+    ];
+
+    protected $casts = [
+        'is_completed' => 'boolean',
+        'completed_at' => 'datetime',
+    ];
+
+    public function workOrder(): BelongsTo
+    {
+        return $this->belongsTo(MaintenanceWorkOrder::class, 'work_order_id');
+    }
+
+    public function completedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'completed_by');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+// AdminPanelProvider.php
+
 namespace App\Providers\Filament;
 
 use Filament\Http\Middleware\Authenticate;
@@ -38,6 +40,7 @@ class AdminPanelProvider extends PanelProvider
             ->sidebarCollapsibleOnDesktop()
             ->sidebarWidth('16rem')
             ->navigationGroups([
+                'Maintenance',
                 'Production',
                 'Procurement',
                 'Inventory',

--- a/database/migrations/2026_01_15_000000_create_equipment_maintenance_tables.php
+++ b/database/migrations/2026_01_15_000000_create_equipment_maintenance_tables.php
@@ -1,0 +1,236 @@
+<?php
+
+// 2026_01_15_000000_create_equipment_maintenance_tables.php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_equipment_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 30)->unique();
+            $table->string('name', 255);
+            $table->text('description')->nullable();
+            $table->enum('default_criticality', ['low', 'medium', 'high', 'critical'])->default('medium');
+            $table->enum('default_usage_unit', ['hours', 'kilometres', 'cycles', 'loads'])->default('hours');
+            $table->integer('default_interval_value')->nullable();
+            $table->enum('default_interval_unit', ['days', 'hours', 'kilometres', 'cycles', 'loads'])->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_equipment_assets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('maintenance_equipment_categories');
+            $table->string('name', 255);
+            $table->string('asset_tag', 100)->nullable()->unique();
+            $table->string('serial_number', 100)->nullable();
+            $table->string('manufacturer', 100)->nullable();
+            $table->string('model', 100)->nullable();
+            $table->integer('year')->nullable();
+            $table->date('purchase_date')->nullable();
+            $table->date('in_service_date')->nullable();
+            $table->enum('status', ['active', 'inactive', 'in_repair', 'out_of_service', 'decommissioned', 'on_hire'])
+                ->default('active');
+            $table->string('location', 255)->nullable();
+            $table->string('department', 255)->nullable();
+            $table->enum('criticality', ['low', 'medium', 'high', 'critical'])->default('medium');
+            $table->enum('usage_unit', ['hours', 'kilometres', 'cycles', 'loads'])->default('hours');
+            $table->decimal('current_usage', 12, 2)->default(0);
+            $table->decimal('next_service_due_usage', 12, 2)->nullable();
+            $table->date('next_service_due_date')->nullable();
+            $table->date('warranty_expiry')->nullable();
+            $table->date('last_inspection_date')->nullable();
+            $table->foreignId('responsible_user_id')->nullable()->constrained('users');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index(['status', 'criticality']);
+        });
+
+        Schema::create('maintenance_usage_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->date('usage_date');
+            $table->decimal('usage_amount', 12, 2);
+            $table->decimal('meter_reading', 12, 2)->nullable();
+            $table->foreignId('logged_by')->nullable()->constrained('users');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->index(['equipment_id', 'usage_date']);
+        });
+
+        Schema::create('maintenance_programs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->string('title', 255);
+            $table->integer('interval_value');
+            $table->enum('interval_unit', ['days', 'hours', 'kilometres', 'cycles', 'loads']);
+            $table->text('checklist')->nullable();
+            $table->text('required_parts')->nullable();
+            $table->text('safety_standards')->nullable();
+            $table->string('procedure_reference', 255)->nullable();
+            $table->decimal('estimated_hours', 10, 2)->nullable();
+            $table->enum('priority', ['low', 'medium', 'high', 'urgent'])->default('medium');
+            $table->boolean('is_active')->default(true);
+            $table->foreignId('created_by')->nullable()->constrained('users');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('maintenance_program_tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('program_id')->constrained('maintenance_programs')->cascadeOnDelete();
+            $table->integer('sequence')->default(1);
+            $table->string('description', 255);
+            $table->boolean('is_mandatory')->default(true);
+            $table->integer('expected_minutes')->nullable();
+            $table->text('reference_notes')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_inspections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->foreignId('inspector_id')->nullable()->constrained('users');
+            $table->date('inspection_date');
+            $table->enum('condition_rating', ['excellent', 'good', 'fair', 'poor', 'critical']);
+            $table->enum('compliance_status', ['compliant', 'non_compliant', 'pending']);
+            $table->text('findings')->nullable();
+            $table->date('next_due_date')->nullable();
+            $table->boolean('follow_up_required')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_fault_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->foreignId('reported_by')->nullable()->constrained('users');
+            $table->dateTime('reported_at');
+            $table->enum('severity', ['low', 'medium', 'high', 'critical']);
+            $table->text('description');
+            $table->text('immediate_action')->nullable();
+            $table->enum('status', ['open', 'in_progress', 'resolved', 'closed'])->default('open');
+            $table->text('resolution_notes')->nullable();
+            $table->dateTime('resolved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_work_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->foreignId('maintenance_program_id')->nullable()->constrained('maintenance_programs');
+            $table->foreignId('fault_report_id')->nullable()->constrained('maintenance_fault_reports');
+            $table->string('title', 255);
+            $table->text('description')->nullable();
+            $table->enum('status', ['open', 'scheduled', 'in_progress', 'blocked', 'completed', 'cancelled'])
+                ->default('open');
+            $table->enum('priority', ['low', 'medium', 'high', 'urgent'])->default('medium');
+            $table->foreignId('requested_by')->nullable()->constrained('users');
+            $table->foreignId('assigned_to')->nullable()->constrained('users');
+            $table->date('scheduled_date')->nullable();
+            $table->date('due_date')->nullable();
+            $table->dateTime('started_at')->nullable();
+            $table->dateTime('completed_at')->nullable();
+            $table->decimal('labour_hours', 10, 2)->nullable();
+            $table->decimal('downtime_hours', 10, 2)->nullable();
+            $table->string('location', 255)->nullable();
+            $table->decimal('meter_reading', 12, 2)->nullable();
+            $table->text('completion_notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index(['status', 'priority']);
+        });
+
+        Schema::create('maintenance_work_order_tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('work_order_id')->constrained('maintenance_work_orders')->cascadeOnDelete();
+            $table->string('description', 255);
+            $table->boolean('is_completed')->default(false);
+            $table->dateTime('completed_at')->nullable();
+            $table->foreignId('completed_by')->nullable()->constrained('users');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_vendors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 255);
+            $table->string('service_type', 100)->nullable();
+            $table->string('contact_name', 255)->nullable();
+            $table->string('email', 255)->nullable();
+            $table->string('phone', 50)->nullable();
+            $table->text('address')->nullable();
+            $table->string('website', 255)->nullable();
+            $table->string('emergency_contact', 255)->nullable();
+            $table->text('notes')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_parts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vendor_id')->nullable()->constrained('maintenance_vendors');
+            $table->string('name', 255);
+            $table->string('part_number', 100)->nullable();
+            $table->string('category', 100)->nullable();
+            $table->decimal('unit_cost', 12, 2)->default(0);
+            $table->integer('quantity_on_hand')->default(0);
+            $table->integer('reorder_point')->nullable();
+            $table->integer('reorder_qty')->nullable();
+            $table->integer('lead_time_days')->nullable();
+            $table->string('inventory_location', 255)->nullable();
+            $table->date('last_stocktake_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->index(['category', 'reorder_point']);
+        });
+
+        Schema::create('maintenance_part_usages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('work_order_id')->constrained('maintenance_work_orders')->cascadeOnDelete();
+            $table->foreignId('part_id')->constrained('maintenance_parts');
+            $table->integer('quantity');
+            $table->decimal('unit_cost', 12, 2)->default(0);
+            $table->decimal('cost_total', 12, 2)->default(0);
+            $table->dateTime('used_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+
+        Schema::create('maintenance_compliance_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('maintenance_equipment_assets')->cascadeOnDelete();
+            $table->string('standard', 255);
+            $table->enum('status', ['compliant', 'non_compliant', 'pending', 'expired'])->default('pending');
+            $table->date('last_audit_date')->nullable();
+            $table->date('next_audit_due')->nullable();
+            $table->text('evidence_location')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('audited_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_compliance_records');
+        Schema::dropIfExists('maintenance_part_usages');
+        Schema::dropIfExists('maintenance_parts');
+        Schema::dropIfExists('maintenance_vendors');
+        Schema::dropIfExists('maintenance_work_order_tasks');
+        Schema::dropIfExists('maintenance_work_orders');
+        Schema::dropIfExists('maintenance_fault_reports');
+        Schema::dropIfExists('maintenance_inspections');
+        Schema::dropIfExists('maintenance_program_tasks');
+        Schema::dropIfExists('maintenance_programs');
+        Schema::dropIfExists('maintenance_usage_logs');
+        Schema::dropIfExists('maintenance_equipment_assets');
+        Schema::dropIfExists('maintenance_equipment_categories');
+    }
+};


### PR DESCRIPTION
### Motivation
- Replace the earlier standalone CLI approach with a first-class Laravel module integrated into the admin UI so maintenance data is managed inside the app.
- Provide a normalized DB schema and Eloquent models for equipment assets, programs, inspections, faults, work orders, parts, vendors, compliance and usage logs to support feature work and reporting.
- Surface essential operational views via Filament resources and a dashboard widget so maintenance workflows are usable by admins without external tooling.

### Description
- Added a single migration `database/migrations/2026_01_15_000000_create_equipment_maintenance_tables.php` which creates tables for categories, assets, usage logs, programs, program tasks, inspections, fault reports, work orders, work order tasks, vendors, parts, part usages and compliance records.
- Implemented Eloquent models under `app/Models/` for the new domain: `MaintenanceEquipmentCategory`, `MaintenanceEquipmentAsset`, `MaintenanceUsageLog`, `MaintenanceProgram`, `MaintenanceProgramTask`, `MaintenanceInspection`, `MaintenanceFaultReport`, `MaintenanceWorkOrder`, `MaintenanceWorkOrderTask`, `MaintenanceVendor`, `MaintenancePart`, `MaintenancePartUsage`, and `MaintenanceComplianceRecord` with sensible casts and relations.
- Added Filament resources and page classes in `app/Filament/Resources/*` to manage categories, assets, programs, inspections, faults, work orders (including nested tasks and part usages), parts, vendors, usage logs and compliance records, plus a `EquipmentMaintenanceOverview` widget under `app/Filament/Widgets/` for high-level stats.
- Integrated the module into the admin UI by adding a `Maintenance` navigation group in `app/Providers/Filament/AdminPanelProvider.php` and removed the previous standalone CLI scripts from `scripts/equipment_maintenance`.

### Testing
- No automated test suite was executed against the new code (`not run`).
- An attempt was made to start the app with `php artisan serve --host=0.0.0.0 --port=8000` but it failed immediately because `vendor/autoload.php` was missing (project dependencies were not installed), so runtime sanity checks could not be performed.
- No migrations or database seed/run checks were executed in CI; please run `composer install` and then `php artisan migrate` in a local/dev environment to validate the migration and resources.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971576fb40c8324b56cbc976dc1d93a)