### PR TITLE
Add route mapping to boot method in all module RouteServiceProviders

### DIFF
--- a/Modules/Backup/Providers/RouteServiceProvider.php
+++ b/Modules/Backup/Providers/RouteServiceProvider.php
@@ -17,6 +17,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     /**

--- a/Modules/Core/Providers/RouteServiceProvider.php
+++ b/Modules/Core/Providers/RouteServiceProvider.php
@@ -19,6 +19,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     /**

--- a/Modules/Finance/Providers/RouteServiceProvider.php
+++ b/Modules/Finance/Providers/RouteServiceProvider.php
@@ -9,6 +9,12 @@ class RouteServiceProvider extends ServiceProvider
 {
     protected $moduleNamespace = 'Modules\Finance\Http\Controllers';
 
+    public function boot(): void
+    {
+        parent::boot();
+        $this->map();
+    }
+
     public function map()
     {
         $this->mapWebRoutes();

--- a/Modules/Inventory/Providers/RouteServiceProvider.php
+++ b/Modules/Inventory/Providers/RouteServiceProvider.php
@@ -17,6 +17,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     /**

--- a/Modules/Nesting/Providers/RouteServiceProvider.php
+++ b/Modules/Nesting/Providers/RouteServiceProvider.php
@@ -10,6 +10,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     public function map(): void

--- a/Modules/Production/Providers/RouteServiceProvider.php
+++ b/Modules/Production/Providers/RouteServiceProvider.php
@@ -10,6 +10,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     public function map(): void

--- a/Modules/Shipping/Providers/RouteServiceProvider.php
+++ b/Modules/Shipping/Providers/RouteServiceProvider.php
@@ -10,6 +10,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     public function map(): void

--- a/Modules/ShopTicket/Providers/RouteServiceProvider.php
+++ b/Modules/ShopTicket/Providers/RouteServiceProvider.php
@@ -18,6 +18,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         parent::boot();
+        $this->map();
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR ensures that routes are properly registered during the service provider boot lifecycle by explicitly calling the `map()` method in all module RouteServiceProviders.

## Changes
- Added `$this->map()` call to the `boot()` method in RouteServiceProviders across all modules:
  - Backup
  - Core
  - Finance
  - Inventory
  - Nesting
  - Production
  - Shipping
  - ShopTicket

## Details
Previously, the `map()` method was defined but not being invoked during the boot phase. By explicitly calling `$this->map()` after `parent::boot()`, we ensure that route registration occurs at the appropriate time in the service provider lifecycle. This is particularly important for the Finance module, which required the addition of the entire `boot()` method as it was previously missing.

This change guarantees consistent route registration behavior across all modules and prevents potential issues where routes might not be properly loaded.